### PR TITLE
feat(ai-context-sync): add --target-dir option to sync command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 This file provides critical context and dependency information for AI agents working on the `dezkareid` monorepo.
 
+## Commit Message Format
+
+Always use Conventional Commits format for commit messages. If the files changed are from a project include the project in the scope. Example: `feat(main-website): [description]` or `feat(design-system): [description]`
+
 ## Critical Dependency Versions
 
 The following versions are established across the project's packages and should be respected when adding new dependencies or troubleshooting.

--- a/packages/ai-context-sync/AGENTS.md
+++ b/packages/ai-context-sync/AGENTS.md
@@ -16,6 +16,8 @@ This package is a CLI utility designed to synchronize AI agent context files (li
 - **Build**: `pnpm build`
 - **Run**: `pnpm start sync` or `node dist/index.js sync`
 - **Options**:
+  - `-d, --dir <path>`: Source directory where `AGENTS.md` lives (defaults to `cwd`).
+  - `-t, --target-dir <path>`: Target directory where synced files are written (defaults to `--dir`). Use this to sync an `AGENTS.md` from one project into a different project directory.
   - `-s, --strategy`: Select specific strategies (e.g., `claude`, `gemini`, `all`, or `"claude, gemini"`).
   - `--skip-config`: Avoid reading/creating the `.ai-context-configrc` file.
   - If no strategy is provided, the tool checks for a `.ai-context-configrc` file.

--- a/packages/ai-context-sync/src/engine.test.ts
+++ b/packages/ai-context-sync/src/engine.test.ts
@@ -111,4 +111,81 @@ describe('SyncEngine', () => {
 
     await expect(engine.sync(tempDir, 'invalid')).rejects.toThrow('No valid strategies found for: invalid. Available strategies: claude, gemini, gemini-md');
   });
+
+  describe('targetDir option', () => {
+    let targetDir: string;
+
+    beforeEach(async () => {
+      targetDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sync-engine-target-'));
+    });
+
+    afterEach(async () => {
+      await fs.remove(targetDir);
+    });
+
+    it('should write synced files to targetDir instead of projectRoot', async () => {
+      const engine = new SyncEngine();
+      const agentsPath = path.join(tempDir, AGENTS_FILENAME);
+      await fs.writeFile(agentsPath, '# Agent Context');
+
+      await engine.sync(tempDir, 'claude', targetDir);
+
+      // File should be in targetDir
+      const claudeInTarget = path.join(targetDir, 'CLAUDE.md');
+      expect(await fs.pathExists(claudeInTarget)).toBe(true);
+
+      // File should NOT be in projectRoot (tempDir)
+      const claudeInSource = path.join(tempDir, 'CLAUDE.md');
+      expect(await fs.pathExists(claudeInSource)).toBe(false);
+    });
+
+    it('should create symlink in targetDir pointing back to projectRoot AGENTS.md', async () => {
+      const engine = new SyncEngine();
+      const agentsPath = path.join(tempDir, AGENTS_FILENAME);
+      await fs.writeFile(agentsPath, '# Agent Context');
+
+      await engine.sync(tempDir, 'claude', targetDir);
+
+      const claudePath = path.join(targetDir, 'CLAUDE.md');
+      const stats = await fs.lstat(claudePath);
+      expect(stats.isSymbolicLink()).toBe(true);
+
+      // The symlink should resolve to the AGENTS.md in projectRoot
+      const resolvedPath = await fs.realpath(claudePath);
+      const expectedPath = await fs.realpath(agentsPath);
+      expect(resolvedPath).toBe(expectedPath);
+    });
+
+    it('should write .gemini/settings.json to targetDir when targetDir is specified', async () => {
+      const engine = new SyncEngine();
+      const agentsPath = path.join(tempDir, AGENTS_FILENAME);
+      await fs.writeFile(agentsPath, '# Agent Context');
+
+      await engine.sync(tempDir, 'gemini', targetDir);
+
+      // Settings should be in targetDir
+      const settingsInTarget = path.join(targetDir, '.gemini', 'settings.json');
+      expect(await fs.pathExists(settingsInTarget)).toBe(true);
+
+      // Settings should NOT be in projectRoot
+      const settingsInSource = path.join(tempDir, '.gemini', 'settings.json');
+      expect(await fs.pathExists(settingsInSource)).toBe(false);
+
+      // The stored path should be relative from targetDir to AGENTS.md
+      const settings = await fs.readJson(settingsInTarget);
+      const expectedRelPath = path.relative(targetDir, agentsPath);
+      expect(settings.context.fileName).toContain(expectedRelPath);
+    });
+
+    it('should use projectRoot as targetDir when targetDir is not specified', async () => {
+      const engine = new SyncEngine();
+      const agentsPath = path.join(tempDir, AGENTS_FILENAME);
+      await fs.writeFile(agentsPath, '# Agent Context');
+
+      await engine.sync(tempDir, 'claude');
+
+      const claudeInSource = path.join(tempDir, 'CLAUDE.md');
+      expect(await fs.pathExists(claudeInSource)).toBe(true);
+    });
+  });
 });

--- a/packages/ai-context-sync/src/engine.ts
+++ b/packages/ai-context-sync/src/engine.ts
@@ -13,8 +13,9 @@ export class SyncEngine {
     new GeminiMdStrategy()
   ];
 
-  async sync(projectRoot: string, selectedStrategies?: string | string[]): Promise<void> {
+  async sync(projectRoot: string, selectedStrategies?: string | string[], targetDir?: string): Promise<void> {
     const agentsPath = path.join(projectRoot, AGENTS_FILENAME);
+    const outputDir = targetDir ?? projectRoot;
 
     if (!(await fs.pathExists(agentsPath))) {
       throw new Error(`${AGENTS_FILENAME} not found in ${projectRoot}`);
@@ -29,11 +30,11 @@ export class SyncEngine {
     } else {
       const selectedList = Array.isArray(selectedStrategies) ? selectedStrategies : [selectedStrategies];
       const normalizedList = selectedList.map(s => s.toLowerCase());
-      
+
       if (normalizedList.includes('all') || normalizedList.includes('both')) {
         strategiesToRun = this.allStrategies;
       } else {
-        strategiesToRun = this.allStrategies.filter(s => 
+        strategiesToRun = this.allStrategies.filter(s =>
           normalizedList.includes(s.name.toLowerCase())
         );
       }
@@ -46,7 +47,7 @@ export class SyncEngine {
 
     for (const strategy of strategiesToRun) {
       console.log(`Syncing for ${strategy.name}...`);
-      await strategy.sync(context, projectRoot);
+      await strategy.sync(context, projectRoot, outputDir);
     }
   }
 }

--- a/packages/ai-context-sync/src/index.ts
+++ b/packages/ai-context-sync/src/index.ts
@@ -16,12 +16,14 @@ program
 program
   .command('sync')
   .description('Synchronize context files from AGENTS.md')
-  .option('-d, --dir <path>', 'Project directory', process.cwd())
+  .option('-d, --dir <path>', 'Project directory (where AGENTS.md lives)', process.cwd())
+  .option('-t, --target-dir <path>', 'Target directory where synced files will be written (defaults to --dir)')
   .option('-s, --strategy <strategy>', 'Sync strategy (claude, gemini, all, or comma-separated list)')
   .option('--skip-config', 'Avoid reading/creating the config file', false)
   .action(async (options) => {
     try {
       const projectRoot = path.resolve(options.dir);
+      const targetDir = options.targetDir ? path.resolve(options.targetDir) : projectRoot;
       const configPath = path.join(projectRoot, CONFIG_FILENAME);
       let strategy = options.strategy;
 
@@ -70,7 +72,7 @@ program
       }
 
       const engine = new SyncEngine();
-      await engine.sync(projectRoot, strategy);
+      await engine.sync(projectRoot, strategy, targetDir);
 
       const strategyMsg = Array.isArray(strategy) ? strategy.join(', ') : strategy;
       console.log(`Successfully synchronized context files using "${strategyMsg}"!`);

--- a/packages/ai-context-sync/src/strategies/gemini.ts
+++ b/packages/ai-context-sync/src/strategies/gemini.ts
@@ -5,9 +5,14 @@ import path from 'path';
 export class GeminiStrategy implements SyncStrategy {
   name = 'gemini';
 
-  async sync(_context: string, projectRoot: string): Promise<void> {
-    const geminiDir = path.join(projectRoot, '.gemini');
+  async sync(_context: string, projectRoot: string, targetDir?: string): Promise<void> {
+    const outputDir = targetDir ?? projectRoot;
+    const geminiDir = path.join(outputDir, '.gemini');
     const settingsPath = path.join(geminiDir, 'settings.json');
+
+    // Compute the path to AGENTS.md relative to the target .gemini directory
+    const agentsAbsPath = path.join(projectRoot, AGENTS_FILE);
+    const agentsRelativePath = path.relative(outputDir, agentsAbsPath);
 
     await fs.ensureDir(geminiDir);
 
@@ -30,17 +35,17 @@ export class GeminiStrategy implements SyncStrategy {
     let modified = false;
 
     if (Array.isArray(currentFiles)) {
-      if (!currentFiles.includes(AGENTS_FILE)) {
-        settings.context.fileName = [...currentFiles, AGENTS_FILE];
+      if (!currentFiles.includes(agentsRelativePath)) {
+        settings.context.fileName = [...currentFiles, agentsRelativePath];
         modified = true;
       }
     } else if (typeof currentFiles === 'string') {
-      if (currentFiles !== AGENTS_FILE) {
-        settings.context.fileName = [currentFiles, AGENTS_FILE];
+      if (currentFiles !== agentsRelativePath) {
+        settings.context.fileName = [currentFiles, agentsRelativePath];
         modified = true;
       }
     } else {
-      settings.context.fileName = [AGENTS_FILE];
+      settings.context.fileName = [agentsRelativePath];
       modified = true;
     }
 

--- a/packages/ai-context-sync/src/strategies/index.ts
+++ b/packages/ai-context-sync/src/strategies/index.ts
@@ -2,7 +2,7 @@ import { AGENTS_FILENAME } from '../constants.js';
 
 export interface SyncStrategy {
   name: string;
-  sync(context: string, projectRoot: string): Promise<void>;
+  sync(context: string, projectRoot: string, targetDir?: string): Promise<void>;
 }
 
 export const AGENTS_FILE = AGENTS_FILENAME;

--- a/packages/ai-context-sync/src/strategies/symlink.test.ts
+++ b/packages/ai-context-sync/src/strategies/symlink.test.ts
@@ -67,13 +67,62 @@ describe('SymlinkStrategy', () => {
   it('should replace existing file with a symlink', async () => {
     const targetPath = path.join(tempDir, 'TEST.md');
     await fs.writeFile(targetPath, 'existing file');
-    
+
     await strategy.sync('', tempDir);
-    
+
     const stats = await fs.lstat(targetPath);
     expect(stats.isSymbolicLink()).toBe(true);
-    
+
     const target = await fs.readlink(targetPath);
     expect(target).toBe(AGENTS_FILE);
+  });
+
+  describe('targetDir option', () => {
+    let targetDir: string;
+
+    beforeEach(async () => {
+      targetDir = await fs.mkdtemp(path.join(os.tmpdir(), 'symlink-strategy-target-'));
+    });
+
+    afterEach(async () => {
+      await fs.remove(targetDir);
+    });
+
+    it('should create symlink in targetDir pointing to AGENTS.md in projectRoot', async () => {
+      await strategy.sync('', tempDir, targetDir);
+
+      const targetPath = path.join(targetDir, 'TEST.md');
+      const stats = await fs.lstat(targetPath);
+      expect(stats.isSymbolicLink()).toBe(true);
+
+      // Symlink should resolve to the actual AGENTS.md in projectRoot
+      const resolvedPath = await fs.realpath(targetPath);
+      const expectedPath = await fs.realpath(path.join(tempDir, AGENTS_FILE));
+      expect(resolvedPath).toBe(expectedPath);
+    });
+
+    it('should not recreate symlink if it already points to the correct location', async () => {
+      const targetPath = path.join(targetDir, 'TEST.md');
+      const agentsAbsPath = path.join(tempDir, AGENTS_FILE);
+      const symlinkTarget = path.relative(targetDir, agentsAbsPath);
+      await fs.ensureSymlink(symlinkTarget, targetPath);
+
+      const initialStats = await fs.lstat(targetPath);
+
+      await strategy.sync('', tempDir, targetDir);
+
+      const finalStats = await fs.lstat(targetPath);
+      expect(finalStats.mtimeMs).toBe(initialStats.mtimeMs);
+    });
+
+    it('should write to projectRoot when targetDir is not provided', async () => {
+      await strategy.sync('', tempDir);
+
+      const targetPath = path.join(tempDir, 'TEST.md');
+      expect(await fs.pathExists(targetPath)).toBe(true);
+
+      const targetPathInTargetDir = path.join(targetDir, 'TEST.md');
+      expect(await fs.pathExists(targetPathInTargetDir)).toBe(false);
+    });
   });
 });

--- a/packages/ai-context-sync/src/strategies/symlink.ts
+++ b/packages/ai-context-sync/src/strategies/symlink.ts
@@ -6,16 +6,21 @@ export abstract class SymlinkStrategy implements SyncStrategy {
   abstract name: string;
   abstract targetFilename: string;
 
-  async sync(_context: string, projectRoot: string): Promise<void> {
-    const targetPath = path.join(projectRoot, this.targetFilename);
-    
+  async sync(_context: string, projectRoot: string, targetDir?: string): Promise<void> {
+    const outputDir = targetDir ?? projectRoot;
+    const targetPath = path.join(outputDir, this.targetFilename);
+
+    // Compute the symlink value: relative path from outputDir to the AGENTS.md in projectRoot
+    const agentsAbsPath = path.join(projectRoot, AGENTS_FILE);
+    const symlinkTarget = path.relative(outputDir, agentsAbsPath);
+
     // Check if it exists and what type it is
     if (await fs.pathExists(targetPath)) {
       const stats = await fs.lstat(targetPath);
       if (stats.isSymbolicLink()) {
-        const target = await fs.readlink(targetPath);
-        if (target === AGENTS_FILE) {
-          // Already points to AGENTS.md, nothing to do
+        const existingTarget = await fs.readlink(targetPath);
+        if (existingTarget === symlinkTarget) {
+          // Already points to the correct location, nothing to do
           return;
         }
       }
@@ -23,7 +28,7 @@ export abstract class SymlinkStrategy implements SyncStrategy {
       await fs.remove(targetPath);
     }
 
-    // Create relative symlink
-    await fs.ensureSymlink(AGENTS_FILE, targetPath);
+    // Create symlink pointing to AGENTS.md
+    await fs.ensureSymlink(symlinkTarget, targetPath);
   }
 }


### PR DESCRIPTION
Add a new `-t, --target-dir <path>` CLI option that allows specifying a separate directory where synced files are written, independent of the source directory where AGENTS.md lives. This enables syncing context from one project into another.

- Update SyncStrategy interface and all strategies to accept optional targetDir
- SymlinkStrategy computes the correct relative path back to AGENTS.md
- GeminiStrategy writes .gemini/settings.json to targetDir with proper relative path
- Add 7 new tests covering targetDir behavior; maintain 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)