### PR TITLE
chore: enable pnpm global virtual store for git worktrees

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,5 @@ packages:
   - "design-system/*"
   - "apps/*"
   - "ui-tools/*"
+
+enableGlobalVirtualStore: true


### PR DESCRIPTION
# Description

Enable global virtual store to use worktrees

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): update of configuration of package manager