### PR TITLE
feat(components): add react-server and react-client entry points

### DIFF
--- a/design-system/components/AGENTS.md
+++ b/design-system/components/AGENTS.md
@@ -8,7 +8,9 @@ Always use Context7 MCP when I need external library/API documentation, code gen
 
 The following paths are the entry points to the different packages:
 
-- `src/react/`: React components (entry: `src/react/index.ts`)
+- `src/react/`: React components (entry: `src/react/index.ts`) — all components, for non-Next.js consumers
+- `src/react-server/`: Server-safe React entry (entry: `src/react-server/index.ts`) — re-exports `Button`, `Card`, `Tag` only
+- `src/react-client/`: Client React entry (entry: `src/react-client/index.ts`) — re-exports `ThemeToggle` only
 - `src/astro/`: Astro components (entry: `src/astro/index.ts`)
 - `src/vue/`: Vue components (entry: `src/vue/index.ts`)
 - `src/css/`: Shared CSS Modules (one file per component, `src/css/index.ts` imports all for the CSS bundle)
@@ -17,12 +19,14 @@ The following paths are the entry points to the different packages:
 
 ## Package Exports
 
-| Export | Points to | Compiled? |
-|---|---|---|
-| `@dezkareid/components/react` | `dist/react.js` | Yes — pre-compiled ES module via Rollup + `@rollup/plugin-typescript` |
-| `@dezkareid/components/astro` | `src/astro/index.ts` | No — compiled by the consuming Astro app |
-| `@dezkareid/components/vue` | `src/vue/index.ts` | No — compiled by the consuming Vite/Vue app |
-| `@dezkareid/components/css` | `dist/components.min.css` | Yes — CSS Modules processed and extracted via `rollup-plugin-postcss` |
+| Export | Points to | Compiled? | Notes |
+|---|---|---|---|
+| `@dezkareid/components/react` | `dist/react/index.js` | Yes — Rollup ESM, `preserveModules` | All components. For non-Next.js React consumers. |
+| `@dezkareid/components/react-server` | `dist/react-server/index.js` | Yes — Rollup ESM, `preserveModules` | `Button`, `Card`, `Tag` only. Safe for Next.js Server Components. No `'use client'`. |
+| `@dezkareid/components/react-client` | `dist/react-client/index.js` | Yes — Rollup ESM, `preserveModules` | `ThemeToggle` only. Every emitted file starts with `'use client'` (injected via Rollup `output.banner`). |
+| `@dezkareid/components/astro` | `src/astro/index.ts` | No — compiled by Astro | |
+| `@dezkareid/components/vue` | `src/vue/index.ts` | No — compiled by Vite/Vue | |
+| `@dezkareid/components/css` | `dist/components.min.css` | Yes — CSS Modules extracted via `rollup-plugin-postcss` | |
 
 ### Why Astro and Vue are not pre-compiled
 
@@ -33,16 +37,24 @@ The following paths are the entry points to the different packages:
 
 The build uses **Rollup** (`rollup.config.mjs`) — not Vite — because `rollup-plugin-postcss` handles CSS Modules extraction correctly in Rollup without conflicts.
 
+`rollup.config.mjs` exports an **array of three configs**, one per React entry point:
+
+1. **`react` config** — `input: src/react/index.ts`, extracts CSS to `dist/components.min.css`
+2. **`react-server` config** — `input: src/react-server/index.ts`, `postcss({ extract: false })` (no CSS duplication)
+3. **`react-client` config** — `input: src/react-client/index.ts`, `output.banner: "'use client';"`, `postcss({ extract: false })`
+
 The build produces:
-- `dist/react.js` — ES module barrel entry
-- `dist/react/**/*.js` — individual component chunks (tree-shakeable via `preserveModules`)
-- `dist/react/**/*.d.ts` — TypeScript declarations
-- `dist/components.min.css` — all CSS Modules processed, scoped, and bundled into one file
+- `dist/react/**/*.js` + `.d.ts` — all components (tree-shakeable via `preserveModules`)
+- `dist/react-server/**/*.js` + `.d.ts` — server-safe components only
+- `dist/react-client/**/*.js` + `.d.ts` — client components; every file starts with `'use client';`
+- `dist/components.min.css` — CSS Modules processed and bundled (emitted by the `react` config only)
 
 Key plugins:
-- `rollup-plugin-postcss` with `autoModules: true, extract: 'components.min.css', minimize: true` — processes CSS Modules and extracts to a single file
+- `rollup-plugin-postcss` with `autoModules: true, minimize: true` — processes CSS Modules; `extract: 'components.min.css'` on the `react` config only, `extract: false` on the others
 - `@rollup/plugin-typescript` with `declaration: true` — compiles TSX and emits `.d.ts` files
 - `@rollup/plugin-node-resolve` — resolves node_modules
+
+**`'use client'` injection:** Rollup 4 strips `"use client"` directive prologs by default. The `react-client` config uses `output.banner: "'use client';"` to prepend the directive to every file it emits. No additional plugin is needed.
 
 ### CSS Modules in the build
 

--- a/design-system/components/README.md
+++ b/design-system/components/README.md
@@ -12,7 +12,9 @@ pnpm add @dezkareid/components @dezkareid/design-tokens
 
 | Export | Points to | Notes |
 |---|---|---|
-| `@dezkareid/components/react` | `dist/react.js` | Pre-compiled ES module, includes `.d.ts` types |
+| `@dezkareid/components/react` | `dist/react/index.js` | Pre-compiled ES module, includes `.d.ts` types. For non-Next.js React consumers. |
+| `@dezkareid/components/react-server` | `dist/react-server/index.js` | Server-safe components only (`Button`, `Card`, `Tag`). Use in Next.js Server Components. |
+| `@dezkareid/components/react-client` | `dist/react-client/index.js` | Client components only (`ThemeToggle`). Ships with `'use client'` directive. Use in Next.js Client Components. |
 | `@dezkareid/components/astro` | `src/astro/index.ts` | Source — compiled by the consuming Astro app |
 | `@dezkareid/components/vue` | `src/vue/index.ts` | Source — compiled by the consuming Vite/Vue app |
 | `@dezkareid/components/css` | `dist/components.min.css` | Pre-compiled CSS Modules bundle |
@@ -38,6 +40,39 @@ import '@dezkareid/components/css';
 > **Note:** The component CSS uses CSS Modules scoped class names. The `@dezkareid/components/css` export is the processed bundle that matches the class names used by the compiled JS — do not import the raw source CSS files from `src/css/`.
 
 Both imports must come before any component usage.
+
+---
+
+## Next.js App Router
+
+When using this package in a Next.js App Router project, import from the entry point that matches the rendering context:
+
+```tsx
+// In a Server Component (no 'use client' needed in your file)
+import { Button, Card, Tag } from '@dezkareid/components/react-server';
+
+export default function Page() {
+  return (
+    <Card elevation="raised">
+      <Tag variant="success">Active</Tag>
+      <Button variant="primary">Get started</Button>
+    </Card>
+  );
+}
+```
+
+```tsx
+// In a Client Component (or a file that already has 'use client')
+import { ThemeToggle } from '@dezkareid/components/react-client';
+
+export default function Header() {
+  return <ThemeToggle />;
+}
+```
+
+> The `react-client` entry point ships with the `'use client'` directive already embedded in the compiled output — you do not need to add it yourself.
+
+For non-Next.js React consumers, `@dezkareid/components/react` continues to export all components unchanged.
 
 ---
 

--- a/design-system/components/package.json
+++ b/design-system/components/package.json
@@ -14,6 +14,16 @@
       "import": "./dist/react.js",
       "default": "./dist/react.js"
     },
+    "./react-server": {
+      "types": "./dist/react-server/index.d.ts",
+      "import": "./dist/react-server/index.js",
+      "default": "./dist/react-server/index.js"
+    },
+    "./react-client": {
+      "types": "./dist/react-client/index.d.ts",
+      "import": "./dist/react-client/index.js",
+      "default": "./dist/react-client/index.js"
+    },
     "./astro": "./src/astro/index.ts",
     "./vue": "./src/vue/index.ts",
     "./css": {
@@ -25,6 +35,12 @@
     "*": {
       "react": [
         "./dist/react/index.d.ts"
+      ],
+      "react-server": [
+        "./dist/react-server/index.d.ts"
+      ],
+      "react-client": [
+        "./dist/react-client/index.d.ts"
       ]
     }
   },

--- a/design-system/components/rollup.config.mjs
+++ b/design-system/components/rollup.config.mjs
@@ -3,30 +3,54 @@ import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import postcss from 'rollup-plugin-postcss';
 
-export default {
-  input: 'src/react/index.ts',
-  external: ['react', 'react/jsx-runtime'],
-  plugins: [
-    resolve({ extensions: ['.ts', '.tsx'] }),
-    commonjs(),
-    postcss({
-      autoModules: true,
-      extract: 'components.min.css',
-      minimize: true,
-    }),
-    typescript({
-      tsconfig: './tsconfig.json',
-      declaration: true,
-      declarationDir: 'dist',
-      exclude: ['**/*.test.tsx', '**/*.test.ts', 'setup-tests.ts'],
-    }),
-  ],
-  output: {
-    dir: 'dist',
-    format: 'es',
-    preserveModules: true,
-    preserveModulesRoot: 'src',
-    entryFileNames: '[name].js',
-    sourcemap: true,
+const external = ['react', 'react/jsx-runtime'];
+
+const plugins = (cssExtract) => [
+  resolve({ extensions: ['.ts', '.tsx'] }),
+  commonjs(),
+  postcss({
+    autoModules: true,
+    extract: cssExtract,
+    minimize: true,
+  }),
+  typescript({
+    tsconfig: './tsconfig.json',
+    declaration: true,
+    declarationDir: 'dist',
+    exclude: ['**/*.test.tsx', '**/*.test.ts', 'setup-tests.ts'],
+  }),
+];
+
+const output = (banner) => ({
+  dir: 'dist',
+  format: 'es',
+  preserveModules: true,
+  preserveModulesRoot: 'src',
+  entryFileNames: '[name].js',
+  sourcemap: true,
+  ...(banner ? { banner } : {}),
+});
+
+export default [
+  // React entry — pre-existing, extracts CSS
+  {
+    input: 'src/react/index.ts',
+    external,
+    plugins: plugins('components.min.css'),
+    output: output(),
   },
-};
+  // React Server Components — server-safe components only, no CSS extraction
+  {
+    input: 'src/react-server/index.ts',
+    external,
+    plugins: plugins(false),
+    output: output(),
+  },
+  // React Client Components — client-only components, "use client" injected via banner
+  {
+    input: 'src/react-client/index.ts',
+    external,
+    plugins: plugins(false),
+    output: output("'use client';"),
+  },
+];

--- a/design-system/components/src/react-client/index.ts
+++ b/design-system/components/src/react-client/index.ts
@@ -1,0 +1,1 @@
+export { ThemeToggle } from '../react/ThemeToggle/index';

--- a/design-system/components/src/react-server/index.ts
+++ b/design-system/components/src/react-server/index.ts
@@ -1,0 +1,3 @@
+export { Button } from '../react/Button/index';
+export { Card } from '../react/Card/index';
+export { Tag } from '../react/Tag/index';


### PR DESCRIPTION
# Description

Adds two new compiled export paths to @dezkareid/components:
- `@dezkareid/components/react-server` — exports Button, Card, Tag (server-safe, no hooks)
- `@dezkareid/components/react-client` — exports ThemeToggle with 'use client' directive injected via Rollup output.banner

The existing `@dezkareid/components/react` entry is unchanged for non-Next.js consumers. Rollup config extended to an array of three configs; CSS extraction remains on the react config only.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):
