### PR TITLE
feat(collectstory): fix theme toggle border, image LCP

### DIFF
--- a/.changeset/fix-theme-toggle-breadcrumb.md
+++ b/.changeset/fix-theme-toggle-breadcrumb.md
@@ -1,0 +1,5 @@
+---
+"@dezkareid/collectstory": patch
+---
+
+Fix theme toggle border, Cloudinary image optimization for LCP, human-readable breadcrumbs with BreadcrumbList schema, Last Arrivals direct item links, and card-to-item view transition.

--- a/apps/collectstory/app/[username]/[collectionSlug]/[slug]/ItemImageSection.tsx
+++ b/apps/collectstory/app/[username]/[collectionSlug]/[slug]/ItemImageSection.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import Image from 'next/image';
+import { ViewTransition } from 'react';
 import { Button } from '@dezkareid/components/react';
+import { CloudinaryImage } from '@/src/shared/ui/CloudinaryImage';
 import { UpdateImageForm } from '@/components/UpdateImageForm/UpdateImageForm';
 import styles from './page.module.css';
 
 type Properties = {
   itemId: string;
+  slug: string;
   imageUrl: string | undefined;
   name: string;
   isOwner: boolean;
@@ -15,7 +17,7 @@ type Properties = {
   collectionSlug: string;
 };
 
-export function ItemImageSection({ itemId, imageUrl, name, isOwner, username, collectionSlug }: Properties) {
+export function ItemImageSection({ itemId, slug, imageUrl, name, isOwner, username, collectionSlug }: Properties) {
   const [currentImageUrl, setCurrentImageUrl] = useState(imageUrl);
   const [editingImage, setEditingImage] = useState(false);
   const [showSuccess, setShowSuccess] = useState(false);
@@ -37,14 +39,15 @@ export function ItemImageSection({ itemId, imageUrl, name, isOwner, username, co
       <div className={`${styles['item-page__image-wrapper']} ${editingImage ? styles['item-page__image-wrapper--editing'] : ''}`}>
         {currentImageUrl
           ? (
-              <Image
-                src={currentImageUrl}
-                alt={name}
-                fill
-                sizes="(max-width: 768px) 100vw, 480px"
-                className={styles['item-page__image-media']}
-                priority
-              />
+              <ViewTransition name={`item-image-${slug}`}>
+                <CloudinaryImage
+                  src={currentImageUrl}
+                  alt={name}
+                  sizes="(max-width: 768px) 100vw, 480px"
+                  className={styles['item-page__image-media']}
+                  priority
+                />
+              </ViewTransition>
             )
           : (
               <div className={styles['item-page__image-placeholder']} aria-hidden="true">

--- a/apps/collectstory/app/[username]/[collectionSlug]/[slug]/_components/OwnerImageSection.tsx
+++ b/apps/collectstory/app/[username]/[collectionSlug]/[slug]/_components/OwnerImageSection.tsx
@@ -4,6 +4,7 @@ import { ItemImageSection } from '../ItemImageSection';
 
 type Properties = {
   itemId: string;
+  slug: string;
   userId: string;
   imageUrl: string | undefined;
   name: string;
@@ -17,7 +18,7 @@ type Properties = {
  * correct isOwner value. Wrapped in <Suspense> on the parent page so it
  * streams in without blocking the cached static shell.
  */
-export async function OwnerImageSection({ itemId, userId, imageUrl, name, username, collectionSlug }: Properties) {
+export async function OwnerImageSection({ itemId, slug, userId, imageUrl, name, username, collectionSlug }: Properties) {
   await connection();
 
   const supabase = await createClient();
@@ -27,6 +28,7 @@ export async function OwnerImageSection({ itemId, userId, imageUrl, name, userna
   return (
     <ItemImageSection
       itemId={itemId}
+      slug={slug}
       imageUrl={imageUrl}
       name={name}
       isOwner={isOwner}

--- a/apps/collectstory/app/[username]/[collectionSlug]/[slug]/page.tsx
+++ b/apps/collectstory/app/[username]/[collectionSlug]/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { createClient } from '@/lib/supabase/server';
 import { getPublicCollectionBySlug, getPublicItemBySlug, type PublicItemDetail } from '@/lib/collections';
 import { DataSchema } from '@/src/shared/ui/DataSchema';
 import { getItemSchema } from '@/src/entities/item';
+import { getBreadcrumbSchema } from '@/src/shared/lib/schema/breadcrumb';
 import { ItemActions } from '@/components/username/ItemActions';
 import { OwnerImageSection } from './_components/OwnerImageSection';
 import { LikeSection } from './_components/LikeSection';
@@ -242,6 +243,7 @@ async function ItemDetail({
       <Suspense fallback={<div className={styles.imageSection} />}>
         <OwnerImageSection
           itemId={item.id}
+          slug={slug}
           userId={item.user_id}
           imageUrl={item.image_url}
           name={item.name}
@@ -265,19 +267,38 @@ async function BreadcrumbNav({
   params: Promise<{ username: string; collectionSlug: string; slug: string }>;
 }) {
   const { username, collectionSlug, slug } = await params;
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? '';
+
+  const collectionResult = await getPublicCollectionBySlug(username, collectionSlug);
+  const collectionName = collectionResult?.collection.name ?? collectionSlug;
+
+  const item = collectionResult
+    ? await getPublicItemBySlug(collectionResult.collection.id, slug, username, collectionSlug)
+    : undefined;
+  const itemName = item?.name ?? slug;
+
+  const breadcrumbSchema = getBreadcrumbSchema([
+    { name: `@${username}`, url: `${baseUrl}/${username}` },
+    { name: collectionName, url: `${baseUrl}/${username}/${collectionSlug}` },
+    { name: itemName, url: `${baseUrl}/${username}/${collectionSlug}/${slug}` },
+  ]);
+
   return (
-    <nav className={styles['item-page__breadcrumb']} aria-label="Breadcrumb">
-      <Link href={`/${username}`} className={styles['item-page__breadcrumb-link']}>
-        @
-        {username}
-      </Link>
-      <span className={styles['item-page__breadcrumb-sep']} aria-hidden="true">/</span>
-      <Link href={`/${username}/${collectionSlug}`} className={styles['item-page__breadcrumb-link']}>
-        {collectionSlug}
-      </Link>
-      <span className={styles['item-page__breadcrumb-sep']} aria-hidden="true">/</span>
-      <span>{slug}</span>
-    </nav>
+    <>
+      <DataSchema schema={breadcrumbSchema} id="breadcrumb-schema" />
+      <nav className={styles['item-page__breadcrumb']} aria-label="Breadcrumb">
+        <Link href={`/${username}`} className={styles['item-page__breadcrumb-link']}>
+          @
+          {username}
+        </Link>
+        <span className={styles['item-page__breadcrumb-sep']} aria-hidden="true">/</span>
+        <Link href={`/${username}/${collectionSlug}`} className={styles['item-page__breadcrumb-link']}>
+          {collectionName}
+        </Link>
+        <span className={styles['item-page__breadcrumb-sep']} aria-hidden="true">/</span>
+        <span>{itemName}</span>
+      </nav>
+    </>
   );
 }
 

--- a/apps/collectstory/app/[username]/[collectionSlug]/page.tsx
+++ b/apps/collectstory/app/[username]/[collectionSlug]/page.tsx
@@ -1,12 +1,13 @@
 import type { Metadata } from 'next';
-import Image from 'next/image';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 import { getCollectionFirstImage, getPublicCollectionBySlug, getPublicItemsInCollection } from '@/lib/collections';
 import { createClient } from '@/lib/supabase/server';
+import { CloudinaryImage } from '@/src/shared/ui/CloudinaryImage';
 import { DataSchema } from '@/src/shared/ui/DataSchema';
 import { getCollectionSchema } from '@/src/entities/collection';
+import { getBreadcrumbSchema } from '@/src/shared/lib/schema/breadcrumb';
 import { CollectionActions } from '@/components/username/CollectionActions';
 import { SocialShare } from '@/src/features/social-share';
 import { IHaveThisButton } from '@/src/features/copy-item';
@@ -123,12 +124,10 @@ async function CollectionContent({
                   <div className={styles.itemImage}>
                     {item.image_url
                       ? (
-                          <Image
+                          <CloudinaryImage
                             src={item.image_url}
                             alt={item.name}
-                            fill
                             sizes="(max-width: 420px) 100vw, (max-width: 720px) 50vw, (max-width: 1024px) 33vw, 25vw"
-                            style={{ objectFit: 'cover' }}
                           />
                         )
                       : (
@@ -175,15 +174,28 @@ async function BreadcrumbNav({
   params: Promise<{ username: string; collectionSlug: string }>;
 }) {
   const { username, collectionSlug } = await params;
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? '';
+
+  const result = await getPublicCollectionBySlug(username, collectionSlug);
+  const collectionName = result?.collection.name ?? collectionSlug;
+
+  const breadcrumbSchema = getBreadcrumbSchema([
+    { name: `@${username}`, url: `${baseUrl}/${username}` },
+    { name: collectionName, url: `${baseUrl}/${username}/${collectionSlug}` },
+  ]);
+
   return (
-    <nav className={styles.breadcrumb} aria-label="Breadcrumb">
-      <Link href={`/${username}`} className={styles.breadcrumbLink}>
-        @
-        {username}
-      </Link>
-      <span className={styles.breadcrumbSep} aria-hidden="true">/</span>
-      <span>{collectionSlug}</span>
-    </nav>
+    <>
+      <DataSchema schema={breadcrumbSchema} id="breadcrumb-schema" />
+      <nav className={styles.breadcrumb} aria-label="Breadcrumb">
+        <Link href={`/${username}`} className={styles.breadcrumbLink}>
+          @
+          {username}
+        </Link>
+        <span className={styles.breadcrumbSep} aria-hidden="true">/</span>
+        <span>{collectionName}</span>
+      </nav>
+    </>
   );
 }
 

--- a/apps/collectstory/app/[username]/page.tsx
+++ b/apps/collectstory/app/[username]/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next';
-import Image from 'next/image';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 import { getPublicCollectionsByUsername } from '@/lib/collections';
+import { CloudinaryImage } from '@/src/shared/ui/CloudinaryImage';
 import { UserProfileActions } from '@/components/username/UserProfileActions';
 import { SocialShare } from '@/src/features/social-share';
 import styles from './page.module.css';
@@ -85,7 +85,8 @@ async function ProfileHeader({ params }: { params: Promise<{ username: string }>
       <div className={styles.avatar}>
         {avatarUrl
           ? (
-              <Image
+              <CloudinaryImage
+                mode="fixed"
                 src={avatarUrl}
                 alt={username}
                 width={72}

--- a/apps/collectstory/app/admin/franchises/page.tsx
+++ b/apps/collectstory/app/admin/franchises/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import Image from 'next/image';
+import { CloudinaryImage } from '@/src/shared/ui/CloudinaryImage';
 import { createClient } from '@/lib/supabase/server';
 import { connection } from 'next/server';
 import { DeleteButton } from '@/components/admin/DeleteButton';
@@ -44,9 +44,10 @@ export default async function FranchisesPage() {
                   <tr key={franchise.id} className={styles.tr}>
                     <td className={styles.td}>
                       {franchise.image_url && (
-                        <Image
+                        <CloudinaryImage
+                          mode="fixed"
                           src={franchise.image_url}
-                          alt=""
+                          alt={franchise.name}
                           width={40}
                           height={40}
                           style={{ objectFit: 'cover', borderRadius: 4 }}

--- a/apps/collectstory/app/franchises/[slug]/page.tsx
+++ b/apps/collectstory/app/franchises/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
-import Image from 'next/image';
 import Link from 'next/link';
+import { CloudinaryImage } from '@/src/shared/ui/CloudinaryImage';
 import { notFound, redirect, RedirectType } from 'next/navigation';
 import {
   getAllFranchiseSlugs,
@@ -62,10 +62,9 @@ export default async function FranchiseDetailPage({ params }: Properties) {
       {/* Hero */}
       <div className={styles.hero}>
         <div className={styles.coverWrap}>
-          <Image
+          <CloudinaryImage
             src={franchise.image_url}
             alt={franchise.name}
-            fill
             sizes="(max-width: 768px) 100vw, 240px"
             className={styles.coverImage}
             priority
@@ -117,10 +116,9 @@ export default async function FranchiseDetailPage({ params }: Properties) {
                       <div className={styles.itemImageWrap}>
                         {item.image_url
                           ? (
-                              <Image
+                              <CloudinaryImage
                                 src={item.image_url}
                                 alt={item.name}
-                                fill
                                 sizes="(max-width: 640px) 50vw, 200px"
                                 className={styles.itemImage}
                               />

--- a/apps/collectstory/app/franchises/page.tsx
+++ b/apps/collectstory/app/franchises/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
-import Image from 'next/image';
 import Link from 'next/link';
+import { CloudinaryImage } from '@/src/shared/ui/CloudinaryImage';
 import { getAllPublicFranchises } from '@/lib/franchises';
 import styles from './page.module.css';
 
@@ -34,10 +34,9 @@ async function FranchiseGrid() {
         <li key={franchise.id}>
           <Link href={`/franchises/${franchise.slug}`} className={styles.card}>
             <div className={styles.cardCover}>
-              <Image
+              <CloudinaryImage
                 src={franchise.image_url}
                 alt={franchise.name}
-                fill
                 sizes="(max-width: 640px) 50vw, (max-width: 1080px) 33vw, 360px"
                 className={styles.cardImage}
               />

--- a/apps/collectstory/components/CollectionItemCard.tsx
+++ b/apps/collectstory/components/CollectionItemCard.tsx
@@ -1,5 +1,5 @@
-import Image from 'next/image';
 import { Tag } from '@dezkareid/components/react-server';
+import { CloudinaryImage } from '@/src/shared/ui/CloudinaryImage';
 import styles from './CollectionItemCard.module.css';
 
 type Properties = {
@@ -28,10 +28,9 @@ export function CollectionItemCard({
       <div className={styles['collection-item-card__image-wrapper']}>
         {imageUrl
           ? (
-              <Image
+              <CloudinaryImage
                 src={imageUrl}
                 alt={name}
-                fill
                 sizes="(max-width: 480px) 100vw, (max-width: 768px) 50vw, 300px"
                 className={styles['collection-item-card__image']}
               />

--- a/apps/collectstory/components/UserMenu/UserMenu.tsx
+++ b/apps/collectstory/components/UserMenu/UserMenu.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState, useRef, useEffect, useCallback } from 'react';
-import Image from 'next/image';
 import Link from 'next/link';
+import { CloudinaryImage } from '@/src/shared/ui/CloudinaryImage';
 import { signOut } from '@/app/actions';
 import styles from './UserMenu.module.css';
 
@@ -53,7 +53,8 @@ export function UserMenu({ username, avatarUrl, email }: UserMenuProperties) {
       >
         {avatarUrl
           ? (
-              <Image
+              <CloudinaryImage
+                mode="fixed"
                 src={avatarUrl}
                 alt={username ?? 'User avatar'}
                 width={32}

--- a/apps/collectstory/components/landing/LatestArrivals.tsx
+++ b/apps/collectstory/components/landing/LatestArrivals.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import * as React from 'react';
-import Image from 'next/image';
+import { ViewTransition } from 'react';
 import Link from 'next/link';
 import { Card } from '@dezkareid/components/react';
 import type { LastArrivalItem } from '@/lib/collections';
+import { CloudinaryImage } from '@/src/shared/ui/CloudinaryImage';
 import styles from './LatestArrivals.module.css';
 
 export function LatestArrivals() {
@@ -60,21 +61,22 @@ export function LatestArrivals() {
                 return (
                   <div key={item.id} className={styles.item} role="listitem">
                     <Link
-                      href={`/${item.username}/${item.collection_slug}`}
+                      href={`/${item.username}/${item.collection_slug}/${item.slug}`}
                       className={styles.itemLink}
                     >
                       <Card elevation="raised" className={styles.card}>
                         <div className={styles.imageWrapper}>
                           {item.image_url
                             ? (
-                                <Image
-                                  src={item.image_url}
-                                  alt={item.name}
-                                  fill
-                                  sizes="(min-width: 60rem) 25vw, (min-width: 37.5rem) 50vw, 100vw"
-                                  loading={index === 0 ? 'eager' : undefined}
-                                  className={styles.image}
-                                />
+                                <ViewTransition name={`item-image-${item.slug}`}>
+                                  <CloudinaryImage
+                                    src={item.image_url}
+                                    alt={item.name}
+                                    sizes="(min-width: 60rem) 25vw, (min-width: 37.5rem) 50vw, 100vw"
+                                    priority={index === 0}
+                                    className={styles.image}
+                                  />
+                                </ViewTransition>
                               )
                             : (
                                 <div className={styles.placeholderImage} aria-hidden="true">📦</div>
@@ -85,9 +87,10 @@ export function LatestArrivals() {
                           {label && <p className={styles.itemLabel}>{label}</p>}
                           <p className={styles.itemAuthor}>
                             {item.avatar_url && (
-                              <Image
+                              <CloudinaryImage
+                                mode="fixed"
                                 src={item.avatar_url}
-                                alt=""
+                                alt={item.username}
                                 width={16}
                                 height={16}
                                 className={styles.avatar}

--- a/apps/collectstory/done/2026-04-10-fix-theme-toggle-breadcrumb/osddt.plan.md
+++ b/apps/collectstory/done/2026-04-10-fix-theme-toggle-breadcrumb/osddt.plan.md
@@ -1,0 +1,534 @@
+# Implementation Plan: Fix Theme Toggle, Breadcrumb, Images & Last Arrivals
+
+## Architecture Overview
+
+This plan covers five discrete work areas across two packages:
+
+1. **`turbo.json` + root `package.json` (monorepo root)** — add `outputs: []` to `lint:fix` turbo task; add `lint:fix` script to root `package.json` (alongside the existing `typecheck` script).
+2. **`design-system/components`** — add `typecheck` npm script; fix ThemeToggle border by replacing the custom `<button>` with `Button variant="ghost"`.
+3. **`apps/collectstory` — Images** — introduce a Cloudinary URL transformation utility; apply it in `CollectionItemCard`, `LatestArrivals`, and the collection page inline image block.
+4. **`apps/collectstory` — Breadcrumb** — replace raw slug text with human-readable names in both `BreadcrumbNav` components; add `BreadcrumbList` JSON-LD to both collection and item detail pages.
+5. **`apps/collectstory` — Last Arrivals link** — fix the `href` to include the item `slug`.
+6. **`apps/collectstory` — View Transition** — card-to-item-page transition using React `<ViewTransition>` + Next.js `experimental.viewTransition`; degrades gracefully on unsupported browsers.
+
+All changes are isolated to the React component sub-tree of the design system and the Next.js app. No new dependencies are introduced. No database schema changes are needed.
+
+---
+
+## Technical Dependencies
+
+- `schema-dts` — already used in `apps/collectstory` for typed JSON-LD. `BreadcrumbList` and `ListItem` types are available.
+- `@dezkareid/components/react` — `Button` component with `ghost` variant; already a dependency of `apps/collectstory`.
+- Cloudinary URL transformation — handled via plain string manipulation (no SDK). Pattern: insert `/c_fill,w_{width},h_{height},q_auto,f_auto/` before the version/filename segment.
+- `turbo.json` `typecheck` and `lint:fix` tasks — already defined at monorepo root; only `design-system/components` is missing the `typecheck` npm script.
+- Root `package.json` — has `typecheck` script (`turbo run typecheck --affected`) but is missing `lint:fix`; needs `"lint:fix": "turbo run lint:fix --affected"` added.
+
+---
+
+## Implementation Phases
+
+### Phase 0 — Turbo & Build Tooling
+
+**Goal**: Ensure `typecheck` and `lint:fix` tasks work for `design-system/components`.
+
+#### Task 0.1 — Add `outputs: []` to `turbo.json` `lint:fix`
+
+`turbo.json` `lint:fix` task is missing `outputs: []`. Without it, Turbo may cache the task result and skip re-running it when source files change. Since lint:fix modifies files (side effects), it must never be cached.
+
+```json
+// turbo.json
+"lint:fix": {
+  "inputs": [...],
+  "outputs": []
+}
+```
+
+#### Task 0.2 — Add `lint:fix` script to root `package.json`
+
+The root `package.json` has `"typecheck": "turbo run typecheck --affected"` but no equivalent for `lint:fix`. Add:
+
+```json
+"lint:fix": "turbo run lint:fix --affected"
+```
+
+This makes `pnpm lint:fix` runnable from the monorepo root, consistent with the existing `lint`, `typecheck`, and `test` scripts.
+
+#### Task 0.3 — Add `typecheck` script to `design-system/components/package.json`
+
+The `turbo.json` `typecheck` task is defined but `@dezkareid/components` has no `typecheck` npm script, so Turbo skips it. Add:
+
+```json
+"typecheck": "tsc --noEmit"
+```
+
+The `tsconfig.json` in `design-system/components` already exists and covers the `src/` tree, so `tsc --noEmit` will work without additional configuration.
+
+---
+
+### Phase 1 — ThemeToggle: Remove Border (design-system/components)
+
+**Goal**: ThemeToggle renders without a visible border in both light and dark mode. Reuse `Button variant="ghost"` to eliminate duplicate style logic.
+
+#### Task 1.1 — Assess Button ghost variant CSS
+
+Confirm that `.button--ghost` in `src/css/button.module.css` has:
+- `background-color: transparent`
+- `border: 1px solid transparent` (invisible border, no layout shift)
+- Hover: `background-color: var(--color-background-secondary)`
+- Focus-visible outline preserved
+
+The ghost variant uses `border: 1px solid transparent` — it does not remove the border from the DOM (to avoid layout shift) but renders it invisibly. This satisfies the requirement: no visible border.
+
+#### Task 1.2 — Refactor `ThemeToggle/index.tsx` to use Button
+
+Replace the custom `<button>` element with `<Button variant="ghost">` from `@dezkareid/components/react`:
+
+- Import `Button` from the same package (internal cross-import within the same build entry is fine since we're in `react/`).
+- Remove `styles['theme-toggle']` class from the button element — it carries the border skin. The layout/structure rules (padding, flex) must be preserved; move them to a wrapper or keep the relevant structural rules in the CSS.
+- Keep `styles['theme-toggle__wrapper']` for the outer `<span>`.
+- Keep `styles['theme-toggle__icon']` for the SVG wrapper.
+- Keep `aria-label`, `aria-pressed`, `onClick` props — pass through to `Button` (it forwards `...rest` to the native `<button>`).
+- The `theme-toggle--dark` modifier only changed border color and text color — with `Button ghost`, text color inherits from the button's skin. We may need to retain a color modifier class on the Button for the dark-mode primary color, or add a `className` prop to set it.
+
+**Decision**: Keep `styles['theme-toggle--dark']` as an additive class passed via `className` to `Button` — it will only carry the `color` override, not the border rule.
+
+#### Task 1.3 — Update `theme-toggle.module.css`
+
+- Remove the `border` declarations from the base `.theme-toggle` skin section and the `.theme-toggle--dark` modifier.
+- Keep structural rules (padding, border-radius, font, display, gap) if they differ from Button's defaults, OR remove them if Button ghost already provides the right structure.
+  - Button `md` size has its own padding — verify it matches ThemeToggle's expected size. If not, keep ThemeToggle's structural class or use a `className` override.
+- Keep `.theme-toggle__icon`, `.theme-toggle__wrapper`, `.sr-only` unchanged.
+
+#### Task 1.4 — Rebuild and verify
+
+Run `pnpm turbo run build --filter=@dezkareid/components` to produce updated `dist/`.
+
+---
+
+### Phase 2 — Cloudinary Image Optimization (apps/collectstory)
+
+**Goal**: All collection item images are served directly from Cloudinary's CDN at the correct size for each viewport — no fixed-width guess, no Next.js image proxy, no JS required.
+
+#### Why replace `next/image` for Cloudinary images
+
+The previous approach passed a single fixed-width Cloudinary URL to `next/image`. This has two problems:
+
+1. **Wrong size**: A 300px URL served to a 320px mobile viewport wastes nothing, but the same 300px URL on a 1440px desktop shows a blurry upscaled image. A fixed width is always wrong for at least part of the viewport range.
+2. **Double proxy**: `next/image` fetches from `/_next/image?url=...`, which re-fetches from Cloudinary origin on the Next.js server. We add a proxy hop for images that Cloudinary's CDN can already serve optimally.
+
+The correct approach is a custom `<CloudinaryImage>` component that generates a native `<img srcset="..." sizes="...">` pointing directly at Cloudinary CDN URLs — no JS, no proxy, works in any RSC or Client Component.
+
+#### Task 2.1 — Rewrite `lib/image/cloudinary.ts`
+
+Replace the fixed-width `getCloudinaryUrl` with two exports:
+
+```ts
+// lib/image/cloudinary.ts
+
+/** Widths for the Cloudinary srcset. Covers all layout contexts in the app. */
+export const CLOUDINARY_SRCSET_WIDTHS = [320, 480, 640, 960, 1280, 1600] as const;
+
+/**
+ * Builds a single Cloudinary URL at a specific width with auto quality and format.
+ * Returns the original URL unchanged if it is not a Cloudinary URL.
+ */
+export function getCloudinaryUrl(
+  url: string,
+  width: number,
+): string {
+  const uploadSegment = '/image/upload/';
+  const idx = url.indexOf(uploadSegment);
+  if (idx === -1) return url;
+
+  const base = url.slice(0, idx + uploadSegment.length);
+  const rest = url.slice(idx + uploadSegment.length);
+  return `${base}c_fill,w_${width},q_auto,f_auto/${rest}`;
+}
+
+/**
+ * Builds a `srcset` string of Cloudinary URLs for all standard widths.
+ * Returns undefined if the URL is not a Cloudinary URL (caller uses plain <img>).
+ */
+export function getCloudinarySrcset(url: string): string | undefined {
+  if (!url.includes('res.cloudinary.com')) return undefined;
+  return CLOUDINARY_SRCSET_WIDTHS
+    .map(w => `${getCloudinaryUrl(url, w)} ${w}w`)
+    .join(', ');
+}
+```
+
+#### Task 2.2 — Create `src/shared/ui/CloudinaryImage/CloudinaryImage.tsx`
+
+A zero-JS server-safe image component:
+
+```tsx
+// src/shared/ui/CloudinaryImage/CloudinaryImage.tsx
+
+import { getCloudinarySrcset, getCloudinaryUrl, CLOUDINARY_SRCSET_WIDTHS } from '@/lib/image/cloudinary';
+
+type Properties = {
+  src: string | undefined;
+  alt: string;
+  sizes: string;
+  /** CSS aspect-ratio value (e.g. "3/4", "1/1", "16/9"). Prevents CLS without JS. */
+  aspectRatio: string;
+  className?: string;
+  priority?: boolean;
+};
+
+export function CloudinaryImage({ src, alt, sizes, aspectRatio, className, priority }: Properties) {
+  if (!src) return null;
+
+  const srcset = getCloudinarySrcset(src);
+
+  // Non-Cloudinary URL (e.g. Google avatar) — plain img, no srcset
+  if (!srcset) {
+    return (
+      <img
+        src={src}
+        alt={alt}
+        style={{ aspectRatio, width: '100%', objectFit: 'cover' }}
+        className={className}
+        loading={priority ? 'eager' : 'lazy'}
+        decoding="async"
+      />
+    );
+  }
+
+  // Use smallest srcset width as the src fallback for browsers without srcset support
+  const fallbackSrc = getCloudinaryUrl(src, CLOUDINARY_SRCSET_WIDTHS[0]);
+
+  return (
+    <img
+      src={fallbackSrc}
+      srcSet={srcset}
+      sizes={sizes}
+      alt={alt}
+      style={{ aspectRatio, width: '100%', objectFit: 'cover' }}
+      className={className}
+      loading={priority ? 'eager' : 'lazy'}
+      fetchPriority={priority ? 'high' : undefined}
+      decoding="async"
+    />
+  );
+}
+```
+
+**Why this works without JS:**
+- `srcset` + `sizes` is pure HTML — the browser picks the right Cloudinary URL at parse time
+- `style="aspect-ratio: 3/4; width: 100%"` defines the box dimensions in CSS — no layout shift
+- `fetchPriority="high"` on LCP images is a browser hint, not JS
+- Works in Server Components, Client Components, and static HTML
+
+Export from `src/shared/ui/CloudinaryImage/index.ts`.
+
+#### Task 2.3 — Remove `next/image` and apply `CloudinaryImage` to all card image sites
+
+Replace `<Image fill sizes=... />` with `<CloudinaryImage>` in:
+
+| Site | `sizes` | `aspectRatio` | `priority` |
+|------|---------|---------------|------------|
+| `CollectionItemCard` | `(max-width: 480px) 100vw, (max-width: 768px) 50vw, 300px` | `"3/4"` | `false` |
+| `LatestArrivals` (first item) | `(min-width: 60rem) 25vw, (min-width: 37.5rem) 50vw, 100vw` | `"3/4"` | `true` (index 0) |
+| `LatestArrivals` (rest) | same | `"3/4"` | `false` |
+| Collection grid | `(max-width: 420px) 100vw, (max-width: 720px) 50vw, (max-width: 1024px) 33vw, 25vw` | `"3/4"` | `false` |
+
+Remove the `getCloudinaryUrl` import and call from each site. Also remove the `position: relative` requirement from image wrappers if it was only needed for `fill` layout.
+
+#### Task 2.4 — Apply `CloudinaryImage` to the item detail hero
+
+`ItemImageSection.tsx` uses `next/image` with `fill`, `sizes="(max-width: 768px) 100vw, 480px"`, and `priority`. The hero uses `object-fit: contain` (not cover).
+
+Use `CloudinaryImage` with `priority={true}` and add an `objectFit` prop or CSS class override for `contain` behaviour:
+
+```tsx
+<CloudinaryImage
+  src={currentImageUrl}
+  alt={name}
+  sizes="(max-width: 768px) 100vw, 480px"
+  aspectRatio="3/4"
+  priority
+  className={styles['item-page__image-media']}
+/>
+```
+
+The existing `.item-page__image-media { object-fit: contain }` CSS class overrides the inline `object-fit: cover` default — no change to CSS needed.
+
+#### Task 2.5 — Remove `next/image` remote pattern for Cloudinary from `next.config.ts`
+
+Once all Cloudinary images bypass `next/image`, the `res.cloudinary.com` remotePattern is no longer needed. Remove it to reduce the attack surface. Keep `lh3.googleusercontent.com` for Google avatar images (still used as plain `<img>` via the non-Cloudinary branch of `CloudinaryImage`).
+
+> **Note**: If any other site still uses `next/image` with Cloudinary URLs, skip this step.
+
+---
+
+### Phase 3 — Breadcrumb: Human-Readable Labels (apps/collectstory)
+
+**Goal**: Both `BreadcrumbNav` components display entity names; both pages emit `BreadcrumbList` JSON-LD.
+
+#### Task 3.1 — Collection page `BreadcrumbNav` — fetch collection name
+
+`BreadcrumbNav` in `app/[username]/[collectionSlug]/page.tsx` currently only has access to params (slugs). To display the collection `name`, it needs to fetch the collection.
+
+The collection data is already fetched in `CollectionContent` (same page, sibling Suspense). To avoid a second DB call, pass the collection name as a prop to `BreadcrumbNav`, or fetch it directly inside `BreadcrumbNav` (it's an async Server Component — no issue with parallel Suspense).
+
+**Decision**: Fetch inside `BreadcrumbNav` using the existing collection query helper. Both `BreadcrumbNav` and `CollectionContent` fetch in parallel via Suspense — Next.js deduplicates identical fetches with `fetch` caching.
+
+```tsx
+async function BreadcrumbNav({ params }) {
+  const { username, collectionSlug } = await params;
+  const collection = await getCollectionBySlug(username, collectionSlug); // existing helper
+  const collectionName = collection?.name ?? collectionSlug; // fallback to slug if not found
+
+  return (
+    <nav aria-label="Breadcrumb">
+      <Link href={`/${username}`}>@{username}</Link>
+      <span aria-hidden="true">/</span>
+      <span>{collectionName}</span>
+    </nav>
+  );
+}
+```
+
+#### Task 3.2 — Item detail page `BreadcrumbNav` — fetch collection and item names
+
+`BreadcrumbNav` in `app/[username]/[collectionSlug]/[slug]/page.tsx` needs both `collection.name` and `item.name`.
+
+The item data is already fetched in `ItemContent` (same page). Same deduplication applies.
+
+```tsx
+async function BreadcrumbNav({ params }) {
+  const { username, collectionSlug, slug } = await params;
+  const [collection, item] = await Promise.all([
+    getCollectionBySlug(username, collectionSlug),
+    getItemBySlug(username, collectionSlug, slug),
+  ]);
+
+  return (
+    <nav aria-label="Breadcrumb">
+      <Link href={`/${username}`}>@{username}</Link>
+      <span aria-hidden="true">/</span>
+      <Link href={`/${username}/${collectionSlug}`}>{collection?.name ?? collectionSlug}</Link>
+      <span aria-hidden="true">/</span>
+      <span>{item?.name ?? slug}</span>
+    </nav>
+  );
+}
+```
+
+#### Task 3.3 — Add `getBreadcrumbSchema` utility
+
+Create `src/shared/lib/schema/breadcrumb.ts` (or extend existing schema files):
+
+```ts
+// apps/collectstory/src/shared/lib/schema/breadcrumb.ts
+import type { BreadcrumbList, ListItem, WithContext } from 'schema-dts';
+
+export interface BreadcrumbItem {
+  name: string;
+  url: string;
+}
+
+export function getBreadcrumbSchema(
+  items: BreadcrumbItem[],
+  baseUrl: string
+): WithContext<BreadcrumbList> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    'itemListElement': items.map((item, index) => ({
+      '@type': 'ListItem',
+      'position': index + 1,
+      'name': item.name,
+      'item': item.url,
+    } as ListItem)),
+  };
+}
+```
+
+#### Task 3.4 — Inject BreadcrumbList into collection page metadata/head
+
+The existing pattern in the item detail page uses a `<DataSchema>` component. Locate `DataSchema` (likely in `src/shared/ui/` or similar) and verify it renders a `<script type="application/ld+json">` tag.
+
+In `app/[username]/[collectionSlug]/page.tsx`, generate and render the breadcrumb schema alongside the existing `CollectionPage` schema:
+
+```tsx
+// In the page component or a dedicated async component:
+const breadcrumbSchema = getBreadcrumbSchema([
+  { name: `@${username}`, url: `${baseUrl}/${username}` },
+  { name: collection.name, url: `${baseUrl}/${username}/${collectionSlug}` },
+], baseUrl);
+
+// Render:
+<DataSchema schema={breadcrumbSchema} />
+```
+
+#### Task 3.5 — Inject BreadcrumbList into item detail page
+
+Same approach in `app/[username]/[collectionSlug]/[slug]/page.tsx`:
+
+```tsx
+const breadcrumbSchema = getBreadcrumbSchema([
+  { name: `@${username}`, url: `${baseUrl}/${username}` },
+  { name: collection.name, url: `${baseUrl}/${username}/${collectionSlug}` },
+  { name: item.name, url: `${baseUrl}/${username}/${collectionSlug}/${slug}` },
+], baseUrl);
+
+<DataSchema schema={breadcrumbSchema} />
+```
+
+---
+
+### Phase 4 — Last Arrivals: Fix Item Link (apps/collectstory)
+
+**Goal**: Cards link to `/username/collection_slug/item_slug`.
+
+#### Task 4.1 — Update `LatestArrivals.tsx` link href
+
+`item.slug` is already present on `LastArrivalItem`. Change:
+
+```tsx
+// Before:
+href={`/${item.username}/${item.collection_slug}`}
+
+// After:
+href={`/${item.username}/${item.collection_slug}/${item.slug}`}
+```
+
+No type changes needed. No API changes needed.
+
+---
+
+### Phase 5 — View Transition: Card → Item Page (apps/collectstory)
+
+**Goal**: Apply a smooth visual transition when the user navigates from a collection item card to the item detail page, using React's View Transitions API with Next.js integration. The API is experimental but degrades gracefully — browsers without support simply skip the animation, so there is no risk of breaking the experience.
+
+#### Research Summary (from Context7 / Next.js v16.1.6 docs)
+
+**API overview:**
+- React ships a `<ViewTransition>` component (available in the Canary channel, importable from `react`)
+- Next.js adds `experimental.viewTransition: true` in `next.config.ts` for deeper framework integration (e.g. auto-adding transition types on navigation)
+- Next.js-specific transition types are not yet implemented — the flag currently only enables the React base component integration
+
+**How it works:**
+1. Enable in `next.config.ts`:
+   ```ts
+   experimental: {
+     viewTransition: true,
+   }
+   ```
+2. Import `<ViewTransition>` from `react`:
+   ```tsx
+   import { ViewTransition } from 'react';
+   ```
+3. Wrap the element you want to animate (e.g. the card image or card container) with `<ViewTransition>` and assign a stable `view-transition-name` CSS property that matches on both the source (card) and the destination (item page):
+   ```tsx
+   // In CollectionItemCard or LatestArrivals card:
+   <ViewTransition name={`item-image-${item.slug}`}>
+     <Image src={...} alt={...} ... />
+   </ViewTransition>
+
+   // In the item detail page, wrap the hero image with the same name:
+   <ViewTransition name={`item-image-${slug}`}>
+     <Image src={...} alt={...} ... />
+   </ViewTransition>
+   ```
+4. The browser natively animates the image from its card position/size to its hero position/size on navigation.
+
+#### Task 5.1 — Enable `experimental.viewTransition` in `next.config.ts`
+
+```ts
+// apps/collectstory/next.config.ts
+const nextConfig = {
+  experimental: {
+    viewTransition: true,
+  },
+  // ...existing config
+};
+```
+
+#### Task 5.2 — Wrap card image in `<ViewTransition>` in `CollectionItemCard`
+
+`src/entities/item/ui/CollectionItemCard.tsx` — wrap the `<Image>` (and its container) with `<ViewTransition>`. The component receives `name` as a prop or derives it from the item slug (needs slug added to `CollectionItemCard` props).
+
+```tsx
+import { ViewTransition } from 'react';
+
+// Add `slug` to CollectionItemCard props:
+type Properties = {
+  slug: string;
+  // ...existing props
+};
+
+// In the render:
+<ViewTransition name={`item-image-${slug}`}>
+  <div className={styles['collection-item-card__image-wrapper']}>
+    <Image src={optimizedUrl} alt={name} fill ... />
+  </div>
+</ViewTransition>
+```
+
+#### Task 5.3 — Wrap hero image in `<ViewTransition>` on item detail page
+
+In `app/[username]/[collectionSlug]/[slug]/page.tsx`, find the item hero image and wrap it with a matching `<ViewTransition name>`:
+
+```tsx
+import { ViewTransition } from 'react';
+
+<ViewTransition name={`item-image-${slug}`}>
+  <div className={styles['item-page__hero-image']}>
+    <Image src={item.image_url} alt={item.name} fill priority />
+  </div>
+</ViewTransition>
+```
+
+The `name` value must be identical on both ends — `item-image-${slug}` — for the browser to connect the two elements and animate between them.
+
+#### Task 5.4 — Apply to `LatestArrivals` cards (optional)
+
+Same pattern as Task 5.2 — wrap the card image in `LatestArrivals.tsx` with `<ViewTransition name={`item-image-${item.slug}`}>`. Since `LatestArrivals` is a Client Component, `<ViewTransition>` (also a client-side feature) works without additional constraints.
+
+#### Caveats & Risks
+
+| Risk | Notes |
+|---|---|
+| `experimental.viewTransition` flag may behave differently across Next.js patch releases | Pin attention to Next.js changelog when upgrading; the flag has no stable API contract yet |
+| React `<ViewTransition>` requires Canary | Confirm `react` version in `apps/collectstory` includes `<ViewTransition>` — React 19.2.4 (currently used) may not include it; check if it needs a canary build |
+| `view-transition-name` must be unique per page | If multiple cards render on the same page, each must have a unique name — using `item-image-${slug}` achieves this as slugs are unique |
+| Graceful degradation | Browsers that don't support View Transitions API simply skip the animation — no broken UI, confirmed safe to ship |
+
+---
+
+### Phase 6 — Changeset
+
+#### Task 6.1 — Create changeset for `@dezkareid/collectstory`
+
+Run `pnpm changeset` from the monorepo root. Select `@dezkareid/collectstory`, bump type `patch`, summary:
+
+```
+Fix theme toggle border, Cloudinary image optimization for LCP, human-readable breadcrumbs with BreadcrumbList schema, and Last Arrivals direct item links.
+```
+
+If `@dezkareid/components` version bump is needed (ThemeToggle change is user-observable), also include it as `patch`.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `Button ghost` padding/sizing differs from current ThemeToggle | Compare computed sizes in Storybook after the change; adjust with a `className` override if needed |
+| `getCollectionBySlug` called twice per collection page (BreadcrumbNav + CollectionContent) | Next.js `fetch` deduplication handles this for same-request identical fetches; verify the query helper uses `fetch` with caching or Supabase's built-in dedup |
+| Cloudinary URL format varies (no version segment, different path structure) | `getCloudinaryUrl` returns the original URL unchanged if the pattern doesn't match; images just render at full resolution as before — no regression |
+| `DataSchema` component location unknown | Must be located before Task 3.4; search `app/[username]/[collectionSlug]/[slug]/page.tsx` imports |
+| `tsc --noEmit` fails in `design-system/components` due to Angular types | Run `pnpm turbo run typecheck --filter=@dezkareid/components` to verify; if Angular types cause issues, scope tsconfig to exclude Angular or use a separate `tsconfig.check.json` |
+
+---
+
+## Out of Scope
+
+- Image upload logic or Cloudinary account/preset configuration
+- Breadcrumbs on any page other than collection and item detail
+- Vue, Astro, or Angular ThemeToggle implementations (React only)
+- New structured data types beyond BreadcrumbList
+- Adding tests for changed components (test suite not yet established for collectstory)

--- a/apps/collectstory/done/2026-04-10-fix-theme-toggle-breadcrumb/osddt.spec.md
+++ b/apps/collectstory/done/2026-04-10-fix-theme-toggle-breadcrumb/osddt.spec.md
@@ -1,0 +1,92 @@
+# Specification: Fix Theme Toggle, Breadcrumb, Images & Last Arrivals
+
+## Overview
+
+This feature addresses four user-facing bugs and quality gaps in the Collectstory application and its shared design system:
+
+1. **ThemeToggle button** displays an unwanted visible border, degrading visual consistency.
+2. **Collection item images** are not served at optimal sizes via Cloudinary, causing poor Largest Contentful Paint (LCP) scores.
+3. **Breadcrumbs** in collection and item pages display raw URL slugs instead of human-readable names, and lack Schema.org BreadcrumbList structured data for SEO.
+4. **Last Arrivals cards** link to the collection page instead of the individual item page, preventing users from navigating directly to the item they see.
+
+These fixes directly improve user experience, site performance, and organic discoverability — all of which are critical to Collectstory's growth targets.
+
+---
+
+## Business Context
+
+These fixes align with the following company outcomes and architecture principles:
+
+**Company Outcomes:**
+- *Expand Collectstory user base by 50% through improved organic discoverability (SEO)*: Adding BreadcrumbList structured data and human-readable breadcrumb labels makes pages more indexable and improves SERP appearance.
+- *Achieve a "High Quality" performance rating on core user devices*: Fixing LCP-impacting unoptimized images directly addresses this key result.
+
+**Architecture Principles:**
+- *Performance-First Design*: Serving correctly-sized images via Cloudinary transformations is a direct application of this principle — performance must not be an afterthought.
+- *Native Discoverability*: BreadcrumbList structured data follows the semantic standards principle — systems must be inherently discoverable by both users and external systems.
+- *Simplicity over Complexity*: Reusing the existing Button `ghost` variant for ThemeToggle avoids maintaining duplicate styling logic across two components.
+
+---
+
+## Requirements
+
+### 1. ThemeToggle — Remove Visible Border
+
+- The ThemeToggle button must not display a visible border in either light or dark mode.
+- The button must remain visually distinct and interactive (hover and focus states preserved).
+- If the existing Button component's `ghost` variant achieves the borderless appearance without custom CSS, it should be used in place of the current custom button implementation.
+
+### 2. Images — Cloudinary Optimized URLs
+
+- Collection item images displayed anywhere in the app (collection grid, item cards, Last Arrivals) must be served using Cloudinary's URL-based transformation capabilities to deliver appropriately resized images.
+- The image URL must include transformation parameters that match the display size context (e.g., thumbnails should not download full-resolution images).
+- This applies to all pages and components that render `image_url` values from collection items.
+
+### 3. Breadcrumb — Human-Readable Labels & BreadcrumbList Schema
+
+- Breadcrumbs on the collection page must display the collection's human-readable name instead of the raw `collectionSlug`.
+- Breadcrumbs on the item detail page must display both the collection's human-readable name and the item's human-readable name instead of their raw slugs.
+- Both pages must emit a valid Schema.org `BreadcrumbList` JSON-LD structured data block in the page `<head>`, reflecting the full breadcrumb trail with correct labels and URLs.
+
+### 4. Last Arrivals — Link to Item, Not Collection
+
+- Each card in the Last Arrivals section must link directly to the individual item page (`/{username}/{collectionSlug}/{itemSlug}`), not to the collection page.
+- The `slug` field is already present on the `LastArrivalItem` type and must be used to construct the correct URL.
+
+---
+
+## Scope
+
+### In Scope
+
+- `design-system/components`: ThemeToggle component styling (border removal, potential Button ghost variant reuse).
+- `apps/collectstory`: All components and pages that render collection item images with Cloudinary URLs.
+- `apps/collectstory`: Breadcrumb UI in collection page and item detail page (human-readable labels).
+- `apps/collectstory`: BreadcrumbList JSON-LD schema for collection page and item detail page.
+- `apps/collectstory`: Last Arrivals card link fix.
+
+### Out of Scope
+
+- Changes to image upload logic or Cloudinary account configuration.
+- Breadcrumb on pages other than collection (`/[username]/[collectionSlug]`) and item detail (`/[username]/[collectionSlug]/[slug]`).
+- Redesigning or restructuring the ThemeToggle component beyond the border fix.
+- Adding new structured data types beyond BreadcrumbList.
+
+---
+
+## Acceptance Criteria
+
+1. **ThemeToggle**: When rendered in both light and dark mode, the ThemeToggle button has no visible border. Hover and focus states remain functional.
+2. **ThemeToggle**: If the Button `ghost` variant is used, there is no duplicate CSS for the ThemeToggle button's base appearance.
+3. **Images**: Collection item images in the collection grid, item cards, and Last Arrivals section are served via Cloudinary URLs that include size transformation parameters appropriate to the display context.
+4. **Images**: LCP-relevant images (above-the-fold, `loading="eager"`) use transformation parameters that avoid downloading oversized images.
+5. **Breadcrumb (Collection page)**: The breadcrumb displays the collection's human-readable `name` instead of `collectionSlug`.
+6. **Breadcrumb (Item detail page)**: The breadcrumb displays both the collection's `name` and the item's `name` instead of their slugs.
+7. **Breadcrumb SEO**: Both collection and item detail pages include a valid `BreadcrumbList` JSON-LD block in the `<head>` that reflects the displayed breadcrumb trail with correct `name` and `id` (URL) values.
+8. **Last Arrivals**: Clicking a card in Last Arrivals navigates to the individual item page (`/{username}/{collectionSlug}/{itemSlug}`), not the collection page.
+
+---
+
+## Open Questions
+
+_None. All requirements are clearly defined based on codebase findings and user description._

--- a/apps/collectstory/done/2026-04-10-fix-theme-toggle-breadcrumb/osddt.tasks.md
+++ b/apps/collectstory/done/2026-04-10-fix-theme-toggle-breadcrumb/osddt.tasks.md
@@ -1,0 +1,110 @@
+# Tasks: Fix Theme Toggle, Breadcrumb, Images & Last Arrivals
+
+Feature: `fix-theme-toggle-breadcrumb`
+Working dir: `apps/collectstory/working-on/fix-theme-toggle-breadcrumb/`
+
+---
+
+## Phase 0 — Turbo & Build Tooling
+
+**Goal**: `typecheck` and `lint:fix` tasks run correctly for all packages including `design-system/components`.
+
+- [x] [S] **0.1** Add `"outputs": []` to the `lint:fix` task in `turbo.json` (monorepo root)
+- [x] [S] **0.2** Add `"lint:fix": "turbo run lint:fix --affected"` to `scripts` in root `package.json`
+- [x] [S] **0.3** Add `"typecheck": "tsc --noEmit"` to `scripts` in `design-system/components/package.json`
+
+**Definition of Done**: `pnpm lint:fix` runs from the repo root without error; `pnpm turbo run typecheck --filter=@dezkareid/components` executes (does not skip).
+
+---
+
+## Phase 1 — ThemeToggle: Remove Visible Border
+
+**Goal**: ThemeToggle has no visible border in light or dark mode. Reuses `Button variant="ghost"` instead of custom border styling.
+
+> Depends on: Phase 0 complete (so typecheck catches regressions)
+
+- [x] [S] **1.1** Read `design-system/components/src/css/button.module.css` — confirm `.button--ghost` uses `border: 1px solid transparent` (invisible, no layout shift) and hover/focus-visible states are intact
+- [x] [M] **1.2** Refactor `design-system/components/src/react/ThemeToggle/index.tsx` — replace the raw `<button>` with `<Button variant="ghost">`; pass `aria-label`, `aria-pressed`, `onClick`, and dark-mode class via `className`; also fix pre-existing `onChange` type conflict by using `Omit<HTMLAttributes<HTMLSpanElement>, 'onChange'>`
+- [x] [S] **1.3** Update `design-system/components/src/css/theme-toggle.module.css` — remove `border` declarations from `.theme-toggle` base skin and `.theme-toggle--dark` modifier; retain structural overrides (padding, font-size) that differ from Button defaults
+- [x] [S] **1.4** Run `pnpm turbo run build --filter=@dezkareid/components` — build succeeded
+
+**Definition of Done**: ThemeToggle renders with no visible border in both light and dark mode; hover and focus-visible states still work; no duplicate border CSS remains. ✅
+
+---
+
+## Phase 2 — Cloudinary Image Optimization
+
+**Goal**: All collection item images served directly from Cloudinary CDN via a native `<img srcset>` — correct size at every viewport, no Next.js proxy, no JS required.
+
+> Previous fixed-width approach (tasks 2.1–2.4) replaced. New design uses `srcset` + `sizes` pointing directly at Cloudinary URLs.
+
+- [x] [S] ~~**2.1** Create `lib/image/cloudinary.ts` with `getCloudinaryUrl(url, { width, height?, fit? })`~~ — superseded
+- [x] [S] ~~**2.2–2.4** Apply fixed-width Cloudinary URL to three sites~~ — superseded
+- [x] [S] **2.1r** Rewrite `apps/collectstory/lib/image/cloudinary.ts` — replace fixed-width function with `getCloudinaryUrl(url, width)`, `getCloudinarySrcset(url)`, and `CLOUDINARY_SRCSET_WIDTHS` constant
+- [x] [M] **2.2r** Create `apps/collectstory/src/shared/ui/CloudinaryImage/CloudinaryImage.tsx` — zero-JS `<img srcset sizes>` component; accepts `src`, `alt`, `sizes`, `aspectRatio`, `priority`, `className`; non-Cloudinary URLs fall back to plain `<img>`; export from `index.ts`
+- [x] [M] **2.3r** Replace `next/image` with `<CloudinaryImage>` in `CollectionItemCard`, `LatestArrivals`, and collection grid page — remove `fill`, `position: relative` image wrapper dependency, and `getCloudinaryUrl` imports
+- [x] [M] **2.4r** Replace `next/image` with `<CloudinaryImage priority>` in `ItemImageSection.tsx` — `sizes="(max-width: 768px) 100vw, 480px"`, keep `.item-page__image-media` CSS class for `object-fit: contain` override
+- [x] [S] **2.5r** Remove `res.cloudinary.com` from `next.config.ts` `remotePatterns` (no longer needed once `next/image` is no longer used for Cloudinary URLs)
+
+**Definition of Done**: All image render sites produce a native `<img srcset>` with Cloudinary CDN URLs; no `/_next/image` proxy requests for Cloudinary images; non-Cloudinary URLs (Google avatar) render as plain `<img>` without srcset; no JS required.
+
+---
+
+## Phase 3 — Breadcrumb: Human-Readable Labels & BreadcrumbList Schema
+
+**Goal**: Breadcrumbs show entity names, not slugs. Both pages emit `BreadcrumbList` JSON-LD.
+
+- [x] [S] **3.1** Locate `DataSchema` component — confirmed at `@/src/shared/ui/DataSchema`; uses `next/script` with `type="application/ld+json"`; updated to accept optional `id` prop (defaults to `"data-schema"`) to support multiple instances per page
+- [x] [M] **3.2** Update `BreadcrumbNav` in `apps/collectstory/app/[username]/[collectionSlug]/page.tsx` — fetches `collection.name` via `getPublicCollectionBySlug`; falls back to slug
+- [x] [M] **3.3** Update `BreadcrumbNav` in `apps/collectstory/app/[username]/[collectionSlug]/[slug]/page.tsx` — fetches `collection.name` then `item.name` sequentially (collection ID needed for item query); falls back to slugs
+- [x] [S] **3.4** Create `apps/collectstory/src/shared/lib/schema/breadcrumb.ts` — `getBreadcrumbSchema(items: BreadcrumbItem[])` returning `WithContext<BreadcrumbList>`
+- [x] [M] **3.5** Inject `<DataSchema id="breadcrumb-schema">` with `BreadcrumbList` in collection `BreadcrumbNav` — two items: profile + collection
+- [x] [M] **3.6** Inject `<DataSchema id="breadcrumb-schema">` with `BreadcrumbList` in item detail `BreadcrumbNav` — three items: profile + collection + item
+
+**Definition of Done**: Collection and item detail pages show human-readable names in the breadcrumb trail; both pages include a valid `BreadcrumbList` JSON-LD block. ✅
+
+---
+
+## Phase 4 — Last Arrivals: Fix Item Link
+
+**Goal**: Each Last Arrivals card links to the individual item page, not the collection.
+
+- [x] [S] **4.1** Update `apps/collectstory/components/landing/LatestArrivals.tsx` — `href` changed to `/${item.username}/${item.collection_slug}/${item.slug}`
+
+**Definition of Done**: Clicking a Last Arrivals card navigates to `/{username}/{collectionSlug}/{itemSlug}`. ✅
+
+---
+
+## Phase 5 — View Transition: Card → Item Page
+
+**Goal**: Smooth shared-element transition between a collection item card image and the item detail page hero image. Degrades gracefully on unsupported browsers.
+
+- [x] [S] **5.1** Verified `<ViewTransition>` availability — React 19.2.4 in node_modules does NOT export it, but Next.js 16 aliases `react` to its internal canary (`19.3.0-canary`) at build time, which does. Import from `react` is safe in App Router code.
+- [x] [S] **5.2** Added `experimental: { viewTransition: true }` to `apps/collectstory/next.config.ts`
+- [x] [M] **5.3** Added `slug` prop to `CollectionItemCard` (`src/entities/item/ui/CollectionItemCard.tsx`); wrapped image with `<ViewTransition name={`item-image-${slug}`}>`. No active call sites required updating (component not yet rendered in pages).
+- [x] [M] **5.4** Threaded `slug` prop through `OwnerImageSection` → `ItemImageSection`; wrapped hero `<Image>` with `<ViewTransition name={`item-image-${slug}`}>` in `ItemImageSection.tsx`
+- [x] [S] **5.5** Wrapped card image in `LatestArrivals.tsx` with `<ViewTransition name={`item-image-${item.slug}`}>`
+
+**Definition of Done**: Navigating from a Last Arrivals card to the item detail page shows a smooth image transition in supported browsers; navigation works normally in unsupported browsers. ✅
+
+---
+
+## Phase 6 — Changeset
+
+- [x] [S] **6.1** Created `.changeset/fix-theme-toggle-breadcrumb.md` — `@dezkareid/collectstory` patch; `@dezkareid/components` is in changeset ignore list so no separate entry needed
+
+**Definition of Done**: A `.changeset/*.md` file exists and is staged for commit.
+
+---
+
+## Dependencies Summary
+
+```
+Phase 0 → Phase 1 (typecheck catches ThemeToggle regressions)
+Phase 2 → Phase 5 (ViewTransition wraps the optimized image)
+Phase 4 → Phase 5 (card must link to correct page before transition)
+Phase 3.1 → Phase 3.5, 3.6 (must locate DataSchema before injecting)
+All phases → Phase 6 (changeset last)
+```
+
+Phases 2, 3, and 4 are independent of each other and can be implemented in any order.

--- a/apps/collectstory/lib/image/cloudinary.ts
+++ b/apps/collectstory/lib/image/cloudinary.ts
@@ -1,0 +1,44 @@
+/**
+ * Cloudinary URL transformation utilities.
+ *
+ * Inserts transformation parameters into a Cloudinary image URL.
+ *
+ * Input:  https://res.cloudinary.com/<cloud>/image/upload/v123/path/to/image.jpg
+ * Output: https://res.cloudinary.com/<cloud>/image/upload/c_fill,w_640,q_auto,f_auto/v123/path/to/image.jpg
+ *
+ * Returns undefined if the URL is not a Cloudinary URL or does not match the
+ * expected upload path structure — callers can fall back to a plain <img>.
+ */
+
+export const CLOUDINARY_SRCSET_WIDTHS = [320, 480, 640, 960, 1280, 1600] as const;
+
+export function getCloudinaryUrl(url: string | undefined, width: number): string | undefined {
+  if (!url || !url.includes('res.cloudinary.com')) return undefined;
+
+  const uploadSegment = '/image/upload/';
+  const index = url.indexOf(uploadSegment);
+  if (index === -1) return undefined;
+
+  const base = url.slice(0, index + uploadSegment.length);
+  const rest = url.slice(index + uploadSegment.length);
+  const transform = `c_fill,w_${width},q_auto,f_auto/`;
+
+  return `${base}${transform}${rest}`;
+}
+
+/**
+ * Generates a `srcset` string with Cloudinary-transformed URLs at each
+ * CLOUDINARY_SRCSET_WIDTHS breakpoint.
+ *
+ * Returns undefined if the URL is not a Cloudinary URL.
+ */
+export function getCloudinarySrcset(url: string | undefined): string | undefined {
+  if (!url || !url.includes('res.cloudinary.com')) return undefined;
+
+  const entries = CLOUDINARY_SRCSET_WIDTHS.map((w) => {
+    const transformed = getCloudinaryUrl(url, w);
+    return transformed ? `${transformed} ${w}w` : undefined;
+  }).filter(Boolean);
+
+  return entries.length > 0 ? entries.join(', ') : undefined;
+}

--- a/apps/collectstory/next-env.d.ts
+++ b/apps/collectstory/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/collectstory/next.config.ts
+++ b/apps/collectstory/next.config.ts
@@ -8,6 +8,9 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+  experimental: {
+    viewTransition: true,
+  },
   cacheComponents: true,
   cacheLife: {
     // User-generated content pages: profile, collection, item detail.
@@ -21,10 +24,6 @@ const nextConfig: NextConfig = {
   },
   images: {
     remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'res.cloudinary.com',
-      },
       {
         protocol: 'https',
         hostname: 'lh3.googleusercontent.com',

--- a/apps/collectstory/src/entities/item/ui/CollectionItemCard.tsx
+++ b/apps/collectstory/src/entities/item/ui/CollectionItemCard.tsx
@@ -1,8 +1,10 @@
-import Image from 'next/image';
+import { ViewTransition } from 'react';
 import { Tag } from '@dezkareid/components/react-server';
+import { CloudinaryImage } from '@/src/shared/ui/CloudinaryImage';
 import styles from './CollectionItemCard.module.css';
 
 type Properties = {
+  slug: string;
   name: string;
   imageUrl: string | undefined;
   brand: string | undefined;
@@ -13,6 +15,7 @@ type Properties = {
 };
 
 export function CollectionItemCard({
+  slug,
   name,
   imageUrl,
   brand,
@@ -28,13 +31,14 @@ export function CollectionItemCard({
       <div className={styles['collection-item-card__image-wrapper']}>
         {imageUrl
           ? (
-              <Image
-                src={imageUrl}
-                alt={name}
-                fill
-                sizes="(max-width: 480px) 100vw, (max-width: 768px) 50vw, 300px"
-                className={styles['collection-item-card__image']}
-              />
+              <ViewTransition name={`item-image-${slug}`}>
+                <CloudinaryImage
+                  src={imageUrl}
+                  alt={name}
+                  sizes="(max-width: 480px) 100vw, (max-width: 768px) 50vw, 300px"
+                  className={styles['collection-item-card__image']}
+                />
+              </ViewTransition>
             )
           : (
               <div className={styles['collection-item-card__image-placeholder']} aria-hidden="true">

--- a/apps/collectstory/src/features/user-menu/ui/UserMenu.tsx
+++ b/apps/collectstory/src/features/user-menu/ui/UserMenu.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import Image from 'next/image';
 import { signOut } from '@/app/actions';
+import { CloudinaryImage } from '@/src/shared/ui/CloudinaryImage';
 import { DropdownMenu, DropdownMenuItem, DropdownDivider } from '@/src/shared/ui/dropdown-menu';
 import styles from './UserMenu.module.css';
 
@@ -26,7 +26,8 @@ export function UserMenu({ username, avatarUrl, email }: Properties) {
         >
           {avatarUrl
             ? (
-                <Image
+                <CloudinaryImage
+                  mode="fixed"
                   src={avatarUrl}
                   alt={username ?? 'User avatar'}
                   width={32}

--- a/apps/collectstory/src/shared/lib/schema/breadcrumb.ts
+++ b/apps/collectstory/src/shared/lib/schema/breadcrumb.ts
@@ -1,0 +1,19 @@
+import type { BreadcrumbList, ListItem, WithContext } from 'schema-dts';
+
+export interface BreadcrumbItem {
+  name: string;
+  url: string;
+}
+
+export function getBreadcrumbSchema(items: BreadcrumbItem[]): WithContext<BreadcrumbList> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    'itemListElement': items.map((item, index) => ({
+      '@type': 'ListItem',
+      'position': index + 1,
+      'name': item.name,
+      'item': item.url,
+    } as ListItem)),
+  };
+}

--- a/apps/collectstory/src/shared/ui/CloudinaryImage/CloudinaryImage.tsx
+++ b/apps/collectstory/src/shared/ui/CloudinaryImage/CloudinaryImage.tsx
@@ -1,0 +1,126 @@
+/* eslint-disable @next/next/no-img-element -- intentional: this component replaces next/image for Cloudinary URLs */
+import type { ImgHTMLAttributes, Ref } from 'react';
+import {
+  CLOUDINARY_SRCSET_WIDTHS,
+  getCloudinarySrcset,
+  getCloudinaryUrl,
+} from '@/lib/image/cloudinary';
+
+type OwnProperties = {
+  /** Original image URL. Cloudinary URLs are optimized; others render as a plain <img>. */
+  src: string | undefined;
+  /**
+   * Rendering mode.
+   *
+   * - `"responsive"` (default): generates a `srcset` + `sizes` for Cloudinary URLs so the
+   *   browser picks the right size at every viewport. Use for fluid-width images.
+   * - `"fixed"`: requests a single Cloudinary-optimized URL at `width` pixels (2× DPR if
+   *   `width` is provided, otherwise the smallest srcset width). Use for avatars, thumbnails,
+   *   and any image rendered at a known fixed size.
+   */
+  mode?: 'responsive' | 'fixed';
+  /**
+   * Required in `"fixed"` mode. The rendered CSS width of the image in pixels.
+   * The component requests `width * 2` from Cloudinary to cover 2× DPR screens.
+   */
+  width?: number;
+  /** Intrinsic aspect ratio (e.g. "1 / 1", "16 / 9"). Prevents CLS before the image loads. */
+  aspectRatio?: string;
+  /** Marks this image as high-priority: sets loading="eager" and fetchPriority="high". Use for LCP images. */
+  priority?: boolean;
+  /** Optional ref forwarded to the underlying <img> element. */
+  ref?: Ref<HTMLImageElement>;
+};
+
+/**
+ * `alt` is required. Everything else from <img> is forwarded as-is.
+ * We omit `srcSet`, `loading`, `decoding`, and `fetchPriority` because the
+ * component derives them from `src`, `mode`, and `priority`.
+ */
+export type Properties = OwnProperties
+  & Omit<
+    ImgHTMLAttributes<HTMLImageElement>,
+    'src' | 'srcSet' | 'loading' | 'decoding' | 'fetchPriority' | 'width' | 'height'
+  > & {
+    alt: string;
+    /**
+     * Passed to the native `sizes` attribute in `"responsive"` mode.
+     * Should always be provided for Cloudinary images so the browser picks the
+     * correct width descriptor. Has no effect in `"fixed"` mode.
+     */
+    sizes?: string;
+    /** Forwarded to the native `width` attribute. Also used in `"fixed"` mode to size the Cloudinary request. */
+    width?: number;
+    /** Forwarded to the native `height` attribute. */
+    height?: number;
+  };
+
+/**
+ * Zero-JS responsive image component.
+ *
+ * Responsive mode (default): renders a native `<img srcset sizes>` pointing directly at
+ * Cloudinary CDN — no Next.js proxy, no JavaScript required.
+ *
+ * Fixed mode: renders a single `<img src>` with a Cloudinary-optimized URL at 2× the
+ * given `width` — ideal for avatars and thumbnails with a known pixel size.
+ *
+ * Non-Cloudinary URLs (e.g. Google OAuth avatar) always fall back to a plain `<img>`.
+ */
+export function CloudinaryImage({
+  src,
+  alt,
+  mode = 'responsive',
+  sizes,
+  aspectRatio,
+  priority,
+  width,
+  height,
+  style,
+  ref,
+  ...rest
+}: Properties) {
+  if (!src) return;
+
+  const computedStyle: React.CSSProperties = mode === 'fixed'
+    ? { ...style }
+    : {
+        width: '100%',
+        height: '100%',
+        objectFit: 'cover',
+        ...(aspectRatio ? { aspectRatio } : {}),
+        ...style,
+      };
+
+  const loadingAttribute: 'eager' | 'lazy' = priority ? 'eager' : 'lazy';
+  const fetchPriorityAttribute: 'high' | undefined = priority ? 'high' : undefined;
+
+  const sharedProperties = {
+    ref,
+    alt,
+    style: computedStyle,
+    loading: loadingAttribute,
+    decoding: 'async' as const,
+    fetchPriority: fetchPriorityAttribute,
+    width,
+    height,
+    ...rest,
+  };
+
+  if (mode === 'fixed') {
+    // Request 2× the rendered width to cover HiDPI screens.
+    const requestWidth = width ? width * 2 : CLOUDINARY_SRCSET_WIDTHS[0];
+    const fixedSource = getCloudinaryUrl(src, requestWidth) ?? src;
+    return <img {...sharedProperties} src={fixedSource} alt={alt} />;
+  }
+
+  // Responsive mode
+  const srcset = getCloudinarySrcset(src);
+
+  if (!srcset) {
+    return <img {...sharedProperties} src={src} alt={alt} />;
+  }
+
+  const fallbackSource = getCloudinaryUrl(src, CLOUDINARY_SRCSET_WIDTHS[0]) ?? src;
+
+  return <img {...sharedProperties} src={fallbackSource} srcSet={srcset} sizes={sizes} alt={alt} />;
+}

--- a/apps/collectstory/src/shared/ui/CloudinaryImage/index.ts
+++ b/apps/collectstory/src/shared/ui/CloudinaryImage/index.ts
@@ -1,0 +1,1 @@
+export { CloudinaryImage } from './CloudinaryImage';

--- a/apps/collectstory/src/shared/ui/DataSchema/DataSchema.tsx
+++ b/apps/collectstory/src/shared/ui/DataSchema/DataSchema.tsx
@@ -6,17 +6,23 @@ export interface DataSchemaProperties {
    * The structured data object (JSON-LD).
    */
   schema: WithContext<Thing> | WithContext<Thing>[];
+  /**
+   * Unique id for the script tag. Required when rendering multiple DataSchema
+   * instances on the same page so Next.js Script can deduplicate correctly.
+   * Defaults to "data-schema" for backwards compatibility.
+   */
+  id?: string;
 }
 
 /**
  * Renders a JSON-LD structured data script tag using next/script.
  */
-export const DataSchema = ({ schema }: DataSchemaProperties) => {
+export const DataSchema = ({ schema, id = 'data-schema' }: DataSchemaProperties) => {
   if (!schema) return;
 
   return (
     <Script
-      id="data-schema"
+      id={id}
       type="application/ld+json"
       data-testid="data-schema"
       strategy="afterInteractive"

--- a/design-system/components/package.json
+++ b/design-system/components/package.json
@@ -74,6 +74,7 @@
   "scripts": {
     "build": "rollup -c rollup.config.mjs && pnpm build:angular",
     "build:angular": "ng-packagr -p ng-package.json",
+    "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "vitest --run --config vitest.config.mts"

--- a/design-system/components/src/css/theme-toggle.module.css
+++ b/design-system/components/src/css/theme-toggle.module.css
@@ -4,37 +4,15 @@
    Skin classes: colour, state
    ============================================================================= */
 
-/* --- Structure: block --- */
+/* --- Structure: block overrides (differs from Button md defaults) --- */
 .theme-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--spacing-8);
-  cursor: pointer;
   padding: var(--spacing-8) var(--spacing-12);
-  border: none;
-  border-radius: var(--spacing-4);
-  font-family: var(--font-family-base);
   font-size: var(--font-size-200);
-  font-weight: var(--font-weight-medium);
-  line-height: var(--font-line-height-none);
 }
 
-/* --- Skin: base --- */
-.theme-toggle {
-  background-color: transparent;
-  color: var(--color-text-primary);
-  border: 1px solid var(--color-background-secondary);
-}
-
-.theme-toggle:hover {
-  background-color: var(--color-background-secondary);
-}
-
-/* --- Skin: state modifier (dark mode active) --- */
+/* --- Skin: state modifier (dark mode active) — color only, no border --- */
 .theme-toggle--dark {
   color: var(--color-primary);
-  border-color: var(--color-primary);
 }
 
 /* --- Structure: icon --- */

--- a/design-system/components/src/react/ThemeToggle/index.tsx
+++ b/design-system/components/src/react/ThemeToggle/index.tsx
@@ -4,9 +4,10 @@ import { useState, useEffect, type HTMLAttributes, type Ref } from 'react';
 import cx from 'classnames';
 import type { Theme, ThemeToggleProperties } from '../../shared/types/theme-toggle';
 import { getInitialTheme, applyTheme, persistTheme } from '../../shared/js/theme';
+import { Button } from '../Button';
 import styles from '../../css/theme-toggle.module.css';
 
-export interface Properties extends ThemeToggleProperties, HTMLAttributes<HTMLSpanElement> {
+export interface Properties extends ThemeToggleProperties, Omit<HTMLAttributes<HTMLSpanElement>, 'onChange'> {
   /**
    * Optional ref forwarded to the wrapper span element.
    * In React 19+, 'ref' is a standard prop and forwardRef is deprecated.
@@ -83,8 +84,8 @@ export function ThemeToggle({
 
   return (
     <span ref={ref} className={cx(styles['theme-toggle__wrapper'], className)} {...rest}>
-      <button
-        type="button"
+      <Button
+        variant="ghost"
         className={cx(styles['theme-toggle'], isDark && styles['theme-toggle--dark'])}
         onClick={toggle}
         aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
@@ -92,7 +93,7 @@ export function ThemeToggle({
       >
         {isDark ? MoonIcon : SunIcon}
         {label}
-      </button>
+      </Button>
       <span aria-live="polite" className={styles['sr-only']}>
         {`${label} mode active`}
       </span>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "prepare": "husky",
     "build": "turbo run build",
     "lint": "turbo run lint --affected",
+    "lint:fix": "turbo run lint:fix --affected",
     "typecheck": "turbo run typecheck --affected",
     "dev": "turbo run dev",
     "test": "turbo run test --affected",

--- a/turbo.json
+++ b/turbo.json
@@ -85,7 +85,8 @@
         "src/**/*.js",
         "server/src/**/*.ts",
         "client/src/**/*.ts"
-      ]
+      ],
+      "outputs": []
     },
     "dev": {
       "dependsOn": [


### PR DESCRIPTION
# Description

- ThemeToggle: replace raw <button> with Button variant="ghost"; remove visible border CSS
- Images: replace next/image with native <img srcset> CloudinaryImage component served directly from Cloudinary CDN (responsive + fixed modes); remove res.cloudinary.com remotePattern
- Breadcrumbs: show human-readable collection/item names; inject BreadcrumbList JSON-LD schema
- Last Arrivals: fix card href to link to item page instead of collection; add view transition
- Turbo: add lint:fix and typecheck scripts to root, components, and turbo.json

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):