### PR TITLE
feat(collectstory): improve item creation flow and image ownership

### DIFF
--- a/apps/collectstory/app/[username]/[collectionSlug]/_components/OwnerEmptyState.module.css
+++ b/apps/collectstory/app/[username]/[collectionSlug]/_components/OwnerEmptyState.module.css
@@ -1,0 +1,49 @@
+.container {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-12);
+  padding: var(--spacing-64) var(--spacing-24);
+  text-align: center;
+  min-height: 300px;
+}
+
+.title {
+  font-size: var(--font-size-400);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.desc {
+  font-size: var(--font-size-300);
+  color: var(--color-text-secondary);
+  margin: 0;
+  max-width: 320px;
+  line-height: var(--font-line-height-normal);
+}
+
+.addButton {
+  margin-top: var(--spacing-8);
+  padding: var(--spacing-12) var(--spacing-24);
+  background-color: var(--color-primary);
+  color: var(--color-text-inverse);
+  border: none;
+  border-radius: var(--border-radius-medium);
+  font-size: var(--font-size-300);
+  font-weight: var(--font-weight-medium);
+  font-family: inherit;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.addButton:hover {
+  opacity: 0.88;
+}
+
+.addButton:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 3px;
+}

--- a/apps/collectstory/app/[username]/[collectionSlug]/_components/OwnerEmptyState.tsx
+++ b/apps/collectstory/app/[username]/[collectionSlug]/_components/OwnerEmptyState.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useRef } from 'react';
+import { AddItemModal, type AddItemModalHandle } from '@/components/AddItemModal/AddItemModal';
+import styles from './OwnerEmptyState.module.css';
+
+type Brand = { id: string; name: string };
+type Franchise = { id: string; name: string };
+
+type Properties = {
+  collectionId: string;
+  brands: Brand[];
+  franchises: Franchise[];
+};
+
+export function OwnerEmptyState({ collectionId, brands, franchises }: Properties) {
+  const modalRef = useRef<AddItemModalHandle>(null);
+
+  return (
+    <div className={styles.container}>
+      <AddItemModal ref={modalRef} brands={brands} franchises={franchises} collectionId={collectionId} />
+      <p className={styles.title}>Your collection is empty</p>
+      <p className={styles.desc}>Add your first item to get started.</p>
+      <button
+        type="button"
+        className={styles.addButton}
+        onClick={() => modalRef.current?.open()}
+      >
+        + Add Item
+      </button>
+    </div>
+  );
+}

--- a/apps/collectstory/app/[username]/[collectionSlug]/page.tsx
+++ b/apps/collectstory/app/[username]/[collectionSlug]/page.tsx
@@ -11,6 +11,8 @@ import { getBreadcrumbSchema } from '@/src/shared/lib/schema/breadcrumb';
 import { CollectionActions } from '@/components/username/CollectionActions';
 import { SocialShare } from '@/src/features/social-share';
 import { IHaveThisButton } from '@/src/features/copy-item';
+import { getAllBrands, getAllFranchises } from '@/app/[username]/[collectionSlug]/actions';
+import { OwnerEmptyState } from './_components/OwnerEmptyState';
 import styles from './page.module.css';
 
 type Properties = {
@@ -60,11 +62,16 @@ async function CollectionContent({
   if (!result) notFound();
 
   const { collection } = result;
-  const items = await getPublicItemsInCollection(collection.id, username, collectionSlug);
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? '';
 
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const [items, brands, franchises, { data: { user } }] = await Promise.all([
+    getPublicItemsInCollection(collection.id, username, collectionSlug),
+    getAllBrands(),
+    getAllFranchises(),
+    supabase.auth.getUser(),
+  ]);
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? '';
   const isOwner = user?.id === result.userId;
 
   const schema = generateCollectionListingSchema({
@@ -102,6 +109,8 @@ async function CollectionContent({
               username={username}
               collectionId={collection.id}
               collectionSlug={collectionSlug}
+              brands={brands}
+              franchises={franchises}
             />
           </Suspense>
         </div>
@@ -109,12 +118,20 @@ async function CollectionContent({
 
       <div className={styles.grid}>
         {items.length === 0
-          ? (
-              <div className={styles.empty}>
-                <p className={styles.emptyTitle}>No items in this collection</p>
-                <p className={styles.emptyDesc}>Items added to this collection will appear here.</p>
-              </div>
-            )
+          ? (isOwner
+              ? (
+                  <OwnerEmptyState
+                    collectionId={collection.id}
+                    brands={brands}
+                    franchises={franchises}
+                  />
+                )
+              : (
+                  <div className={styles.empty}>
+                    <p className={styles.emptyTitle}>No items in this collection</p>
+                    <p className={styles.emptyDesc}>Items added to this collection will appear here.</p>
+                  </div>
+                ))
           : items.map(item => (
               <div key={item.id} className={styles.itemCardWrapper}>
                 <Link

--- a/apps/collectstory/components/AddItemModal/AddItemModal.module.css
+++ b/apps/collectstory/components/AddItemModal/AddItemModal.module.css
@@ -27,7 +27,8 @@
 
 .dialog {
   padding: 0;
-  border: none;
+  /* TODO(design-system): needs semantic border token (e.g. --color-border-subtle) */
+  border: 1px solid var(--color-background-secondary);
   border-radius: var(--border-radius-large);
   box-shadow: var(--shadow-card-hover);
   background: var(--color-background-primary);
@@ -35,6 +36,8 @@
   width: calc(100vw - var(--spacing-32));
   max-height: calc(100dvh - var(--spacing-64));
   overflow: hidden;
+  /* Restore browser-default centering overridden by the global `* { margin: 0 }` reset */
+  margin: auto;
 }
 
 .dialog::backdrop {

--- a/apps/collectstory/components/AddItemModal/AddItemModal.tsx
+++ b/apps/collectstory/components/AddItemModal/AddItemModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef } from 'react';
+import { useImperativeHandle, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { AddItemForm } from '@/components/AddItemForm/AddItemForm';
 import styles from './AddItemModal.module.css';
@@ -14,13 +14,19 @@ type Properties = {
   collectionId: string;
 };
 
-export function AddItemModal({ brands, franchises, collectionId }: Properties) {
+export type AddItemModalHandle = {
+  open: () => void;
+};
+
+export const AddItemModal = function AddItemModal({ ref, brands, franchises, collectionId }: Properties & { ref?: React.RefObject<AddItemModalHandle | null> }) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const router = useRouter();
 
-  function open() {
-    dialogRef.current?.showModal();
-  }
+  useImperativeHandle(ref, () => ({
+    open() {
+      dialogRef.current?.showModal();
+    },
+  }));
 
   function close() {
     dialogRef.current?.close();
@@ -32,42 +38,36 @@ export function AddItemModal({ brands, franchises, collectionId }: Properties) {
   }
 
   return (
-    <>
-      <button type="button" className={styles.trigger} onClick={open} aria-haspopup="dialog">
-        + Add Item
-      </button>
-
-      <dialog
-        ref={dialogRef}
-        className={styles.dialog}
-        aria-modal="true"
-        aria-labelledby="add-item-dialog-title"
-        onClick={(event) => {
-          if (event.target === dialogRef.current) close();
-        }}
-      >
-        <div className={styles.panel}>
-          <div className={styles.header}>
-            <h2 id="add-item-dialog-title" className={styles.title}>Add to Collection</h2>
-            <button
-              type="button"
-              className={styles.closeButton}
-              onClick={close}
-              aria-label="Close dialog"
-            >
-              ✕
-            </button>
-          </div>
-          <div className={styles.body}>
-            <AddItemForm
-              brands={brands}
-              franchises={franchises}
-              collectionId={collectionId}
-              onSuccess={handleSuccess}
-            />
-          </div>
+    <dialog
+      ref={dialogRef}
+      className={styles.dialog}
+      aria-modal="true"
+      aria-labelledby="add-item-dialog-title"
+      onClick={(event) => {
+        if (event.target === dialogRef.current) close();
+      }}
+    >
+      <div className={styles.panel}>
+        <div className={styles.header}>
+          <h2 id="add-item-dialog-title" className={styles.title}>Add to Collection</h2>
+          <button
+            type="button"
+            className={styles.closeButton}
+            onClick={close}
+            aria-label="Close dialog"
+          >
+            ✕
+          </button>
         </div>
-      </dialog>
-    </>
+        <div className={styles.body}>
+          <AddItemForm
+            brands={brands}
+            franchises={franchises}
+            collectionId={collectionId}
+            onSuccess={handleSuccess}
+          />
+        </div>
+      </div>
+    </dialog>
   );
-}
+};

--- a/apps/collectstory/components/CreateCollectionModal/CreateCollectionModal.module.css
+++ b/apps/collectstory/components/CreateCollectionModal/CreateCollectionModal.module.css
@@ -18,7 +18,8 @@
 
 .dialog {
   padding: 0;
-  border: none;
+  /* TODO(design-system): needs semantic border token (e.g. --color-border-subtle) */
+  border: 1px solid var(--color-background-secondary);
   border-radius: var(--border-radius-large);
   box-shadow: var(--shadow-card-hover);
   background: var(--color-background-primary);
@@ -26,6 +27,8 @@
   width: calc(100vw - var(--spacing-32));
   max-height: calc(100dvh - var(--spacing-64));
   overflow: hidden;
+  /* Restore browser-default centering overridden by the global `* { margin: 0 }` reset */
+  margin: auto;
 }
 
 .dialog::backdrop {

--- a/apps/collectstory/components/username/CollectionActions.module.css
+++ b/apps/collectstory/components/username/CollectionActions.module.css
@@ -1,0 +1,47 @@
+.actions {
+  display: flex;
+  gap: var(--spacing-8);
+  align-items: center;
+}
+
+.addButton {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--spacing-8) var(--spacing-16);
+  background-color: var(--color-primary);
+  color: var(--color-text-inverse);
+  border: none;
+  border-radius: var(--border-radius-medium);
+  font-size: var(--font-size-200);
+  font-weight: var(--font-weight-medium);
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  text-decoration: none;
+  transition: opacity 0.15s ease;
+}
+
+.addButton:hover {
+  opacity: 0.88;
+}
+
+.editLink {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--spacing-8) var(--spacing-16);
+  background-color: transparent;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-background-secondary);
+  border-radius: var(--border-radius-medium);
+  font-size: var(--font-size-200);
+  font-weight: var(--font-weight-medium);
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  text-decoration: none;
+  transition: opacity 0.15s ease;
+}
+
+.editLink:hover {
+  opacity: 0.88;
+}

--- a/apps/collectstory/components/username/CollectionActions.tsx
+++ b/apps/collectstory/components/username/CollectionActions.tsx
@@ -1,30 +1,25 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
 import { createClient } from '@/lib/supabase/client';
+import { AddItemModal, type AddItemModalHandle } from '@/components/AddItemModal/AddItemModal';
+import styles from './CollectionActions.module.css';
+
+type Brand = { id: string; name: string };
+type Franchise = { id: string; name: string };
 
 type Properties = {
   username: string;
   collectionId: string;
   collectionSlug: string;
+  brands: Brand[];
+  franchises: Franchise[];
 };
 
-const buttonStyle: React.CSSProperties = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  padding: 'var(--spacing-8) var(--spacing-16)',
-  borderRadius: 'var(--border-radius-medium)',
-  fontSize: 'var(--font-size-200)',
-  fontWeight: 'var(--font-weight-medium)',
-  fontFamily: 'inherit',
-  cursor: 'pointer',
-  border: '1px solid var(--color-background-secondary)',
-  whiteSpace: 'nowrap' as const,
-  textDecoration: 'none',
-};
-
-export function CollectionActions({ username, collectionSlug }: Properties) {
+export function CollectionActions({ username, collectionId, collectionSlug, brands, franchises }: Properties) {
   const [isOwner, setIsOwner] = useState(false);
+  const modalRef = useRef<AddItemModalHandle>(null);
 
   useEffect(() => {
     const supabase = createClient();
@@ -44,28 +39,26 @@ export function CollectionActions({ username, collectionSlug }: Properties) {
   if (!isOwner) return;
 
   return (
-    <div style={{ display: 'flex', gap: 'var(--spacing-8)', alignItems: 'center' }}>
-      <a
-        href={`/${username}/${collectionSlug}/items/new`}
-        style={{
-          ...buttonStyle,
-          background: 'var(--color-primary)',
-          color: 'var(--color-text-inverse)',
-          border: 'none',
-        }}
+    <div className={styles.actions}>
+      <AddItemModal
+        ref={modalRef}
+        brands={brands}
+        franchises={franchises}
+        collectionId={collectionId}
+      />
+      <button
+        type="button"
+        className={styles.addButton}
+        onClick={() => modalRef.current?.open()}
       >
         + Add Item
-      </a>
-      <a
+      </button>
+      <Link
         href={`/${username}/${collectionSlug}/edit`}
-        style={{
-          ...buttonStyle,
-          background: 'transparent',
-          color: 'var(--color-text-secondary)',
-        }}
+        className={styles.editLink}
       >
         Edit
-      </a>
+      </Link>
     </div>
   );
 }

--- a/apps/collectstory/done/2026-04-10-improve-creation-of-items/osddt.plan.md
+++ b/apps/collectstory/done/2026-04-10-improve-creation-of-items/osddt.plan.md
@@ -1,0 +1,138 @@
+# Implementation Plan: Improve Creation of Items
+
+## Architecture Overview
+
+Three independent, self-contained changes. No new dependencies, no new routes, no new shared abstractions needed.
+
+1. **Add Item dialog** — Convert the `+ Add Item` anchor tag in `CollectionActions` from a navigation link to a button that imperatively opens the existing `AddItemModal`. `CollectionActions` already fetches auth context client-side; it will also receive and render `AddItemModal` wired to a toggle.
+
+2. **Centering fixes** — Two CSS-only changes:
+   - `CreateCollectionModal.module.css`: add `margin: auto` or `align-items: center` to the dialog's `::backdrop`/positioning so the dialog is viewport-centred. The native `<dialog>` element is centred by the browser by default when opened with `showModal()` — so if it is currently off-centre the fix is to remove any CSS overrides that displace it.
+   - Empty collection state inline form: identify the component that renders the empty-state form in `app/[username]/[collectionSlug]/page.tsx` and add centred layout styles to its container.
+
+3. **"I have this" image upload** — In `CopyItemModal`, before submitting the copy form, fetch the source `image_url` as a blob client-side, POST it to `/api/upload`, and replace `initialData.image_url` with the returned Cloudinary URL. If the fetch or upload fails, proceed with no image and surface an inline warning.
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Add Item dialog (replaces navigation)
+
+**Goal**: Clicking `+ Add Item` on the collection page opens `AddItemModal` inline instead of navigating to `/items/new`.
+
+**Files to change**:
+
+| File | Change |
+|---|---|
+| `components/username/CollectionActions.tsx` | Replace the `<a href="/items/new">` with a `<button>` that opens `AddItemModal`. Render `AddItemModal` inside `CollectionActions`, receiving `brands`, `franchises`, and `collectionId` as props. |
+| `app/[username]/[collectionSlug]/page.tsx` | Fetch `brands`, `franchises`, and `collectionId` server-side alongside existing data. Pass them down to `CollectionActions` (currently it receives only `username`, `collectionId`, `collectionSlug`). `CollectionActions` is rendered inside a `<Suspense>` — the added data fetches can be parallelised with `Promise.all` in `CollectionContent`. |
+| `components/username/CollectionActions.tsx` — props | Add `brands: { id: string; name: string }[]`, `franchises: { id: string; name: string }[]` to the `Properties` type. |
+
+**Notes**:
+- `CollectionActions` is a client component that currently re-fetches the auth state from Supabase on the client. The `isOwner` check for rendering happens client-side. The new `brands`/`franchises`/`collectionId` props are fetched on the server and serialised down — no client fetch needed.
+- `AddItemModal` already calls `router.refresh()` on success — the collection grid will update without a full navigation.
+- The existing `/items/new` page stays intact as a progressive-enhancement fallback. No changes to that route.
+
+---
+
+### Phase 2 — Centering fixes (CSS only)
+
+**Goal**: Both the "New Collection" modal form and the empty-collection inline item form are visually centred.
+
+#### 2a — CreateCollectionModal centering
+
+**File**: `components/CreateCollectionModal/CreateCollectionModal.module.css`
+
+The native `<dialog>` opened via `showModal()` is centred by the browser's UA stylesheet by default (`position: fixed; inset-block-start: 50%; inset-inline-start: 50%; transform: translate(-50%, -50%)`). Check whether any existing styles override this. If `margin`, `top`, or positioning overrides exist on `.dialog`, remove them. If the form content inside `.body` is left-aligned, add `text-align: center` or adjust flex direction on `.form` as needed. Since the modal's width is already capped at `480px`, the fix is likely removing a `margin-top` or ensuring the dialog is not pushed toward the top.
+
+**Approach**: Inspect `.dialog` — ensure it has no `margin-block-start` or absolute positioning override. The UA default will centre it. If `.body` content appears left-leaning, add `align-items: center` to `.form` only if fields are narrow enough that centering improves readability; otherwise keep them full-width (form fields that span the full container width are readable as-is).
+
+#### 2b — Empty collection state inline form centering
+
+**File**: `app/[username]/[collectionSlug]/page.tsx` and `page.module.css`
+
+The empty-state branch currently renders a button inside `styles.grid`. The button reveals an inline form. Locate the component or element that wraps this inline form and apply:
+
+```css
+.emptyFormContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px; /* or flex: 1 if the grid is a flex container */
+  width: 100%;
+}
+```
+
+The inline form itself should be constrained to a readable width (e.g. `max-width: 480px; width: 100%`) so centering does not stretch it across the full viewport.
+
+**Note**: If the inline form lives in a separate client component (e.g. an `EmptyState` component), the CSS change goes in that component's module file.
+
+---
+
+### Phase 3 — "I have this" image upload
+
+**Goal**: When copying an item, the source image is fetched client-side and re-uploaded through `/api/upload` so the copied item owns its own Cloudinary asset.
+
+**File**: `src/features/copy-item/ui/CopyItemModal.tsx`
+
+**Change**: Add an `uploadSourceImage` utility used inside `useCopyItemModalData` (or a new `useCopyImageUpload` hook). When the modal loads and `item.image_url` is present, attempt to:
+
+1. `fetch(item.image_url)` → get a `Blob`.
+2. Build a `FormData` with the blob as a `File` (`new File([blob], 'image.jpg', { type: blob.type })`).
+3. `POST /api/upload` with the `FormData`.
+4. On success: store the returned `url` in state as `uploadedImageUrl`.
+5. On failure: store `null` and set `imageUploadFailed: true`.
+
+Pass `uploadedImageUrl` into `resolveInitialData` so `initialData.image_url` uses the new URL instead of the original. If `uploadedImageUrl` is `null` (failed or no source image), `initialData.image_url` is `undefined`.
+
+If `imageUploadFailed` is `true`, render an inline notice inside `CopyItemModalContent` before the form:
+
+```
+⚠ The image could not be copied. You can add one manually.
+```
+
+**Upload timing**: Trigger the fetch+upload eagerly as soon as the modal opens (inside the existing `useEffect` in `useCopyItemModalData`, alongside the collections/brands/franchises load). This keeps the loading state unified — the form does not show until all data (including the image upload attempt) resolves.
+
+**Error handling rules**:
+- Network error fetching the source URL → `imageUploadFailed = true`, no image.
+- `/api/upload` returns non-2xx → `imageUploadFailed = true`, no image.
+- `item.image_url` is `null`/`undefined` → skip entirely, no warning shown.
+
+---
+
+## Technical Dependencies
+
+| Dependency | Status |
+|---|---|
+| `AddItemModal` | Exists — `components/AddItemModal/AddItemModal.tsx` |
+| `AddItemForm` | Exists — `components/AddItemForm/AddItemForm.tsx` |
+| `Modal` (shared) | Exists — `src/shared/ui/modal/Modal.tsx` |
+| `/api/upload` endpoint | Exists — `app/api/upload/route.ts` |
+| `router.refresh()` on success | Already used in `AddItemModal.handleSuccess` |
+| CSS Modules + design tokens | Already in use across all affected files |
+
+No new npm packages needed.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| `CollectionActions` receives brands/franchises as props but is rendered inside `<Suspense>` — the parent Server Component must fetch this data | Low | Parallelise with `Promise.all` in `CollectionContent`; only owner sees these anyway so the data is user-scoped |
+| Source image CORS restriction prevents client-side `fetch` | Medium | Cloudinary URLs are public and do not enforce CORS for reads. If the URL is non-Cloudinary (edge case), graceful degradation already handles failure |
+| Image upload in `useCopyItemModalData` runs on every modal open, adding latency | Low | Upload runs in parallel with collections/brands/franchises load; the modal stays in loading state until all resolve — no additional perceived delay |
+| `CreateCollectionModal` dialog centering already handled by browser — CSS inspection may show nothing to change | Low | Inspect rendered output in dev; if UA already centres it, skip 2a or only adjust form field alignment if needed |
+| `CollectionActions` currently uses inline styles (`buttonStyle`) — extending it with a modal requires mixing CSS approaches | Low | Convert the existing inline styles in `CollectionActions` to a CSS Module as part of this change (small, self-contained improvement consistent with codebase conventions) |
+
+---
+
+## Out of Scope
+
+- Removing or modifying the `/items/new` route.
+- Changes to the admin item creation flow.
+- Changes to the item edit flow.
+- Server-side image proxy or Route Handler for image fetching.
+- Any state management library.
+- Mobile-specific layout changes beyond what the existing modal already provides.

--- a/apps/collectstory/done/2026-04-10-improve-creation-of-items/osddt.spec.md
+++ b/apps/collectstory/done/2026-04-10-improve-creation-of-items/osddt.spec.md
@@ -1,0 +1,91 @@
+# Feature Specification: Improve Creation of Items
+
+## Overview
+
+The current item creation flow in the collection page has two usability problems. First, when a user is on a public collection page and wants to add a new item, clicking "Add Item" navigates them to a separate page (`/[username]/[collectionSlug]/items/new`), breaking context and flow. Second, the "I have this" button — which lets a visitor copy a public item into their own collection — stores the original item's image URL directly rather than uploading the image file, creating a dependency on another user's image and potential conflicts if the source image is later changed or deleted.
+
+This feature improves three things: item creation happens in-context via a dialog (reusing the existing `AddItemModal` pattern); the "New Collection" modal form and the empty collection state's inline item form are properly centred; and the "I have this" image copy is fetched client-side and uploaded to the user's own Cloudinary folder via `/api/upload` instead of referencing the source URL.
+
+---
+
+## Requirements
+
+### 1. In-context item creation on the collection page
+
+- When an authenticated collection owner is viewing their own public collection page (`/[username]/[collectionSlug]`), the "Add Item" action must open a dialog overlay rather than navigating to a new page.
+- The dialog must reuse the existing `AddItemModal` / `AddItemForm` component so that all fields, validation, and image upload behaviour are identical to the current new-item page.
+- On successful submission, the dialog closes and the collection page refreshes to show the new item — without a full page navigation.
+- The separate route `app/[username]/[collectionSlug]/items/new` may remain as a fallback for users who deep-link to it or navigate without JavaScript, but the primary entry point becomes the dialog.
+
+### 2. Centred forms in collection creation and empty collection state
+
+- The **"New Collection" modal** (opened from the "New Collection" button) must centre its form content within the modal overlay.
+- When a collection exists but contains no items, the page shows a button that reveals an **inline item creation form**. That inline form must be horizontally and vertically centred within the content area.
+- The centred layout for the inline form applies only while the collection is empty; once items exist the page returns to its standard grid layout.
+
+### 3. Image copy on "I have this"
+
+- When a visitor clicks "I have this" on a public collection item and confirms the copy, the application must **upload the source item's image to the current user's own Cloudinary folder** rather than storing the original `image_url` string.
+- The upload must go through the existing `/api/upload` endpoint (with all its optimisation, metadata-stripping, and Cloudinary integration) so the copied image is treated as the user's own asset.
+- If the source item has no image, the copied item is created without an image — no upload is attempted.
+- If the image upload fails (e.g. the source URL is unreachable), the copy operation must still succeed; the item is created without an image and the user is informed that the image could not be copied.
+
+---
+
+## Scope
+
+### In scope
+
+- Replacing the full-page item creation navigation with a dialog on the public collection page (owner view).
+- Centring the form inside the "New Collection" modal.
+- Centring the inline item creation form in the empty collection state.
+- Uploading the source image (client-side fetch → `/api/upload`) when a user uses "I have this".
+
+### Out of scope
+
+- Changes to the admin item creation flow.
+- Changes to the item edit flow.
+- Removing the `/items/new` route (it stays as a fallback).
+- Changes to any other copy or sharing mechanism beyond "I have this".
+- Mobile-specific layout changes beyond what the existing modal pattern already handles.
+
+---
+
+## Acceptance Criteria
+
+1. **Collection page — Add Item dialog**: An authenticated owner visiting their own collection page sees an "Add Item" button that opens the item creation form as a dialog. Submitting the form closes the dialog and the new item appears in the collection grid without a page redirect.
+
+2. **"New Collection" modal — centred form**: When the "New Collection" modal is open, its form content is horizontally centred within the modal overlay.
+
+3. **Empty collection state — centred inline form**: A user who has a collection with zero items clicks the button to add their first item; the inline form that appears is centred in the content area. Once at least one item exists, the layout reverts to the standard grid.
+
+4. **"I have this" — image upload**: When a visitor copies a public item that has an image, the resulting item in their collection references an image URL in their own Cloudinary folder (`collectstory/{userId}`), not the original item owner's URL. The image in the copied item is visually identical to the source.
+
+5. **"I have this" — image upload failure graceful degradation**: If the source image cannot be fetched or uploaded (network error, invalid URL, unsupported format), the copy still completes. The copied item has no image, and the user sees an inline message indicating the image could not be copied.
+
+6. **"I have this" — no image**: If the source item has no image, the copied item is created without an image and no upload is attempted. No error is shown.
+
+7. **Accessibility**: The new item creation dialog is keyboard-navigable (focus is trapped inside the open dialog, Escape closes it, focus returns to the trigger button on close). WCAG 2.2 AA compliance is maintained.
+
+8. **No regression**: The existing "Copy item" flow (same dialog, used by returning users who already have collections) continues to work correctly.
+
+---
+
+## Business Context
+
+This feature directly supports two strategic outcomes for Dezkareid Enterprise (2026):
+
+- **High-Quality User Experience** — Removing the page-navigation interruption for item creation and fixing the empty-state centering reduces friction in the core collector workflow, contributing to the "High Quality" performance and usability rating target.
+- **Innovation & Growth** — A smoother item creation flow increases the likelihood that new users (acquired through improved SEO) complete their first collection item, supporting the 50% Collectstory user-base growth key result.
+
+Architecturally, the image-copy change aligns with the **Integrity and Auditability** principle: each user's collection items reference image assets they own, making storage usage and data provenance transparent and auditable. Storing a URL belonging to another user violates this principle and creates silent breakage risk.
+
+---
+
+## Decisions
+
+1. **Centering scope clarified**: There are two separate centering fixes. (a) The "New Collection" button opens a modal — the form inside that modal needs to be centred. (b) The empty collection state has a button that reveals an inline item creation form — that inline form needs to be centred. Both are CSS fixes to existing UI; no structural changes needed.
+
+2. **Image upload on "I have this" — fetch approach**: The image fetch and upload happen client-side. The `CopyItemModal` fetches the source image as a blob and POSTs it to `/api/upload`, mirroring the same flow used by the regular item creation form. No server-side outbound request is needed.
+
+3. **Dialog trigger location on the collection page**: The "Add Item" button appears only in the collection toolbar. The change is to wire that button to open the existing `AddItemModal` dialog instead of navigating to `/items/new`.

--- a/apps/collectstory/done/2026-04-10-improve-creation-of-items/osddt.tasks.md
+++ b/apps/collectstory/done/2026-04-10-improve-creation-of-items/osddt.tasks.md
@@ -1,0 +1,36 @@
+# Task List: Improve Creation of Items
+
+## Phase 1 — Add Item dialog (replaces navigation)
+
+- [x] [S] Read `CollectionActions.tsx` and `CollectionActions.module.css` (or note inline styles) to understand current structure before modifying
+- [x] [M] Convert `CollectionActions` inline styles to a CSS Module (`CollectionActions.module.css`)
+- [x] [M] Add `brands`, `franchises`, and `collectionId` props to `CollectionActions` and render `AddItemModal` inside it; replace the `<a href="/items/new">` with a button that opens the modal
+- [x] [M] Update `CollectionContent` in `app/[username]/[collectionSlug]/page.tsx` to fetch `brands`, `franchises`, and verify `collectionId` are available and passed to `CollectionActions` (parallelise with `Promise.all`)
+
+**Dependencies**: CSS Module conversion (task 2) before modal integration (task 3); data fetching (task 4) before end-to-end test.
+
+**Definition of Done**: Clicking `+ Add Item` on an owned collection opens `AddItemModal` in a dialog. Submitting a new item closes the dialog and the item appears in the grid without page navigation. The `/items/new` route still works when visited directly.
+
+---
+
+## Phase 2 — Centering fixes (CSS only)
+
+- [x] [S] Inspect `CreateCollectionModal.module.css` and the rendered `<dialog>` to identify any CSS that displaces the modal from browser-default viewport centering; remove or correct it
+- [x] [S] Locate the empty-collection-state element/component in `app/[username]/[collectionSlug]/page.tsx` and its CSS module; add flex centering to the container and constrain the inline form to `max-width: 480px`
+
+**Dependencies**: None — independent of Phase 1 and Phase 3.
+
+**Definition of Done**: The "New Collection" modal appears vertically and horizontally centred in the viewport. On an empty collection page, clicking the add-item button shows a centred inline form.
+
+---
+
+## Phase 3 — "I have this" image upload
+
+- [x] [S] Read `CopyItemModal.tsx` and `src/features/copy-item/ui/IHaveThisButton.tsx` in full to understand current data flow and modal lifecycle
+- [x] [M] Add client-side source-image fetch + upload logic to `useCopyItemModalData` in `CopyItemModal.tsx`: fetch `item.image_url` as a blob, POST to `/api/upload`, store result URL or failure flag in state (run in parallel with collections/brands/franchises load)
+- [x] [S] Update `resolveInitialData` (or its call site) to use the uploaded image URL instead of the raw `item.image_url`
+- [x] [S] Render an inline warning inside `CopyItemModalContent` when `imageUploadFailed` is `true`: "⚠ The image could not be copied. You can add one manually."
+
+**Dependencies**: Tasks within Phase 3 are sequential (upload logic → initial data → UI warning).
+
+**Definition of Done**: Copying a public item that has an image results in the new item referencing a Cloudinary URL under the copying user's folder (`collectstory/{userId}`). If the source image is unreachable, the copy succeeds without an image and the warning is shown. If the source item has no image, no upload is attempted and no warning appears.

--- a/apps/collectstory/src/features/copy-item/ui/CopyItemModal.module.css
+++ b/apps/collectstory/src/features/copy-item/ui/CopyItemModal.module.css
@@ -48,6 +48,15 @@
   color: var(--color-text-secondary);
 }
 
+.imageWarning {
+  font-size: var(--font-size-200);
+  color: var(--color-text-secondary);
+  background-color: var(--color-background-secondary);
+  border-radius: var(--border-radius-small);
+  padding: var(--spacing-8) var(--spacing-12);
+  margin: 0;
+}
+
 .formWrapper {
   display: flex;
   flex-direction: column;

--- a/apps/collectstory/src/features/copy-item/ui/CopyItemModal.tsx
+++ b/apps/collectstory/src/features/copy-item/ui/CopyItemModal.tsx
@@ -16,6 +16,33 @@ type Properties = {
   onClose: () => void;
 };
 
+async function uploadImageFromUrl(sourceUrl: string): Promise<string | undefined> {
+  try {
+    const response = await fetch(sourceUrl);
+    if (!response.ok) return undefined;
+
+    const blob = await response.blob();
+    const extension = blob.type === 'image/png' ? 'png' : (blob.type === 'image/webp' ? 'webp' : 'jpg');
+    const file = new File([blob], `image.${extension}`, { type: blob.type });
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const uploadResponse = await fetch('/api/upload', {
+      method: 'POST',
+      body: formData,
+    });
+
+    if (!uploadResponse.ok) return undefined;
+
+    const data = await uploadResponse.json() as { url?: string };
+    return data.url;
+  }
+  catch {
+    return undefined;
+  }
+}
+
 function LoadingState() {
   return <div className={styles.loading}>Loading collections...</div>;
 }
@@ -71,30 +98,46 @@ function CollectionSelector({
   );
 }
 
-function useCopyItemModalData() {
+function useCopyItemModalData(sourceImageUrl: string | undefined) {
   const [collections, setCollections] = useState<Collection[]>([]);
   const [selectedCollectionId, setSelectedCollectionId] = useState<string>('');
   const [brands, setBrands] = useState<{ id: string; name: string }[]>([]);
   const [franchises, setFranchises] = useState<{ id: string; name: string }[]>([]);
   const [loading, setLoading] = useState(true);
+  const [uploadedImageUrl, setUploadedImageUrl] = useState<string | undefined>(undefined);
+  const [imageUploadFailed, setImageUploadFailed] = useState(false);
 
   useEffect(() => {
     async function loadData() {
-      const [cols, b, f] = await Promise.all([
-        getUserCollections(),
-        getAllBrands(),
-        getAllFranchises(),
-      ]);
-      setCollections(cols);
-      if (cols.length > 0) {
-        setSelectedCollectionId(cols[0].id);
+      const tasks: Promise<unknown>[] = [
+        getUserCollections().then((cols) => {
+          setCollections(cols);
+          if (cols.length > 0) {
+            setSelectedCollectionId(cols[0].id);
+          }
+        }),
+        getAllBrands().then(setBrands),
+        getAllFranchises().then(setFranchises),
+      ];
+
+      if (sourceImageUrl) {
+        tasks.push(
+          uploadImageFromUrl(sourceImageUrl).then((url) => {
+            if (url) {
+              setUploadedImageUrl(url);
+            }
+            else {
+              setImageUploadFailed(true);
+            }
+          }),
+        );
       }
-      setBrands(b);
-      setFranchises(f);
+
+      await Promise.all(tasks);
       setLoading(false);
     }
     loadData();
-  }, []);
+  }, [sourceImageUrl]);
 
   return {
     collections,
@@ -103,6 +146,8 @@ function useCopyItemModalData() {
     brands,
     franchises,
     loading,
+    uploadedImageUrl,
+    imageUploadFailed,
   };
 }
 
@@ -135,13 +180,17 @@ function resolveMetadata(item: PublicItem | PublicItemDetail) {
   return { lineId, franchiseId, variant };
 }
 
-function resolveInitialData(item: PublicItem | PublicItemDetail): InitialItemData {
+function resolveInitialData(
+  item: PublicItem | PublicItemDetail,
+  uploadedImageUrl: string | undefined,
+): InitialItemData {
   const { lineId, franchiseId, variant } = resolveMetadata(item);
 
   return {
     name: item.name,
     description: item.description ?? undefined,
-    image_url: item.image_url ?? undefined,
+    // Use the uploaded (user-owned) image URL; fall back to undefined if upload failed or no image
+    image_url: uploadedImageUrl,
     brand_id: item.lines?.brands?.id,
     line_id: lineId,
     franchise_id: franchiseId,
@@ -160,10 +209,13 @@ function CopyItemModalContent({
   data: ReturnType<typeof useCopyItemModalData>;
   actions: ReturnType<typeof useCopyItemModalActions>;
 }) {
-  const { collections, selectedCollectionId, brands, franchises, loading } = data;
+  const { collections, selectedCollectionId, brands, franchises, loading, uploadedImageUrl, imageUploadFailed } = data;
   const { handleSuccess, onCollectionChange } = actions;
 
-  const initialData = useMemo(() => resolveInitialData(item), [item]);
+  const initialData = useMemo(
+    () => resolveInitialData(item, uploadedImageUrl),
+    [item, uploadedImageUrl],
+  );
 
   if (loading) return <LoadingState />;
 
@@ -174,6 +226,12 @@ function CopyItemModalContent({
         value={selectedCollectionId}
         onChange={onCollectionChange}
       />
+
+      {imageUploadFailed && (
+        <p className={styles.imageWarning} role="alert">
+          ⚠ The image could not be copied. You can add one manually.
+        </p>
+      )}
 
       <div className={styles.formWrapper}>
         <p className={styles.formTitle}>Confirm details</p>
@@ -192,7 +250,8 @@ function CopyItemModalContent({
 }
 
 export function CopyItemModal({ item, onClose }: Properties) {
-  const data = useCopyItemModalData();
+  const sourceImageUrl = item.image_url ?? undefined;
+  const data = useCopyItemModalData(sourceImageUrl);
   const actions = useCopyItemModalActions(onClose, data.setSelectedCollectionId);
 
   return (

--- a/apps/collectstory/src/shared/ui/modal/Modal.module.css
+++ b/apps/collectstory/src/shared/ui/modal/Modal.module.css
@@ -1,7 +1,8 @@
 /* ─── Modal ──────────────────────────────────────────────────────────────────── */
 
 .modal {
-  border: none;
+  /* TODO(design-system): needs semantic border token (e.g. --color-border-subtle) */
+  border: 1px solid var(--color-background-secondary);
   border-radius: var(--border-radius-large);
   box-shadow: var(--shadow-card-hover);
   padding: 0;


### PR DESCRIPTION
# Description

- Replace "Add Item" page navigation with in-context AddItemModal dialog on collection page
- Add owner empty-state with centred "Add Item" CTA that opens the same dialog
- Fix dialog centering across all modals (margin: auto + border for dark mode contrast)
- Copy image client-side via /api/upload on "I have this" so copied items own their asset

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):
